### PR TITLE
Add support for Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,9 @@ RUN apt-get install -y \
     libatlas-base-dev \
     libopencv-dev \
     lsb-release \
-    sudo
-
-RUN apt-get install -y \
     python-numpy \
     python3-numpy \
+    sudo
     wget
 
 WORKDIR /usr/local

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM nvidia/cuda:8.0-cudnn5-devel-ubuntu16.04
+
+RUN apt-get update
+RUN apt-get install -y \
+    libatlas-base-dev \
+    libopencv-dev \
+    lsb-release \
+    sudo
+
+RUN apt-get install -y \
+    python-numpy \
+    python3-numpy \
+    wget
+
+WORKDIR /usr/local
+
+COPY . .
+
+RUN ./install_caffe_and_openpose.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get install -y \
     lsb-release \
     python-numpy \
     python3-numpy \
-    sudo
+    sudo \
     wget
 
 WORKDIR /usr/local

--- a/install_caffe_and_openpose.sh
+++ b/install_caffe_and_openpose.sh
@@ -25,7 +25,6 @@ function executeShInItsFolder {
     # $3 = folder to go back
     cd $2
     exitIfError
-    sudo chmod +x $1
     exitIfError
     ./$1
     exitIfError

--- a/install_openpose.sh
+++ b/install_openpose.sh
@@ -25,7 +25,6 @@ function executeShInItsFolder {
     # $3 = folder to go back
     cd $2
     exitIfError
-    sudo chmod +x $1
     exitIfError
     ./$1
     exitIfError


### PR DESCRIPTION
Adds a Dockerfile to support Docker, using [nvidia-docker](https://github.com/NVIDIA/nvidia-docker), as it uses cuda. To run the demo (with the help of [a tutorial](http://wiki.ros.org/docker/Tutorials/GUI)), having a camara:

```shell
nvidia-docker build -t openpose .
xhost +local:root
nvidia-docker run \
    -ti \
    --rm \
    -v /tmp/.X11-unix:/tmp/.X11-unix:rw \
    -e QT_X11_NO_MITSHM=1 \
    -e DISPLAY \
    --device=/dev/video0:/dev/video0 \
    openpose \
        .build_release/examples/openpose/openpose.bin
```

I needed to remove the "chmod" calls from the scripts, as it conflicted with Docker. They were useless btw, as the +x is already present.

And I'm not sure which one of "python-numpy" and "python3-numpy" is required, so I installed both to avoid wasting a lot of time building twice :sweat_smile:. But if you do know, I can remove the other one.