### PR TITLE
fix wrong json file format

### DIFF
--- a/src/openpose/filestream/cocoJsonSaver.cpp
+++ b/src/openpose/filestream/cocoJsonSaver.cpp
@@ -60,7 +60,7 @@ namespace op
                 // keypoints - i.e. poseKeypoints
                 mJsonOfstream.key("keypoints");
                 mJsonOfstream.arrayOpen();
-                const std::vector<int> indexesInCocoOrder{0, 15, 14, 17, 16,        5, 2, 6, 3, 7, 4,       11, 8, 12, 9, 13, 10};
+                const std::vector<int> indexesInCocoOrder{0, 15, 14, 17, 16,        5, 2, 6, 3, 7,        4, 11, 8, 12, 9,        13, 10};
                 for (auto bodyPart = 0 ; bodyPart < indexesInCocoOrder.size() ; bodyPart++)
                 {
                     const auto finalIndex = 3*(person*numberBodyParts + indexesInCocoOrder.at(bodyPart));
@@ -69,7 +69,7 @@ namespace op
                     mJsonOfstream.plainText(poseKeypoints[finalIndex+1]);
                     mJsonOfstream.comma();
                     mJsonOfstream.plainText(1);
-                    if (bodyPart < numberBodyParts-2)
+                    if (bodyPart < indexesInCocoOrder.size() - 1)
                         mJsonOfstream.comma();
                 }
                 mJsonOfstream.arrayClose();

--- a/src/openpose/filestream/cocoJsonSaver.cpp
+++ b/src/openpose/filestream/cocoJsonSaver.cpp
@@ -69,7 +69,7 @@ namespace op
                     mJsonOfstream.plainText(poseKeypoints[finalIndex+1]);
                     mJsonOfstream.comma();
                     mJsonOfstream.plainText(1);
-                    if (bodyPart < numberBodyParts-1)
+                    if (bodyPart < numberBodyParts-2)
                         mJsonOfstream.comma();
                 }
                 mJsonOfstream.arrayClose();


### PR DESCRIPTION
COCO challenge only has 17 keypoints, so indexesInCocoOrder.size()==17.
openpose added the neck keypoint (index 1), therefore numberBodyParts==18.
numberBodyParts-1==17, Statement `if (bodyPart < numberBodyParts-1)` adds a comma for  every bodyPart ([0..16]), add a extra comma in the end, causing a bad json format file, which can not be proporly parsed.