### PR TITLE
Typo in part_to_show description

### DIFF
--- a/doc/demo_overview.md
+++ b/doc/demo_overview.md
@@ -119,7 +119,7 @@ Please, in order to check all the real time pose demo options and their details,
 - `--write_keypoint path/`: Output JSON, XML or YML files with the people pose data on the `path/` folder.
 - `--process_real_time`: It might skip frames in order to keep the final output displaying frames on real time.
 - `--disable_blending`: If selected, it will only render the pose skeleton or desired heat maps, while blocking the original background. Also related: `part_to_show`, `alpha_pose`, and `alpha_pose`.
-- `--part_to_show`: Select the prediction channel to visualize (default: 0). 0 to visualize all the body parts, 1-18 for each body part heat map, 19 for the background heat map, 20 for all the body part heat maps together, 21 for all the PAFs, 22-69 for each body part pair PAF.
+- `--part_to_show`: Select the prediction channel to visualize (default: 0). 0 to visualize all the body parts, 1-18 for each body part heat map, 19 for the background heat map, 20 for all the body part heat maps together, 21 for all the PAFs, 22-40 for each body part pair PAF.
 - `--no_display`: Display window not opened. Useful if there is no X server and/or to slightly speed up the processing if visual output is not required.
 - `--num_gpu 2 --num_gpu_start 1`: Parallelize over this number of GPUs starting by the desired device id. Default `num_gpu` is -1, which will use all the available GPUs.
 - `--scale_number 3 --scale_gap 0.15`: Use 3 scales, 1, (1-0.15), (1-0.15*2). Default is one scale. If you want to change the initial scale, you actually want to multiply your desired initial scale by the `net_resolution`.


### PR DESCRIPTION
part_to_show only goes on till 40 for COCO pairs, not 69, because there are 19 pairs for COCO. Gives an error when you set `--part_to_show` beyond 40 @gineshidalgo99 