### PR TITLE
Fix of the script for caffe and openpose TX2

### DIFF
--- a/ubuntu/install_caffe_and_openpose_JetsonTX2_JetPack3.1.sh
+++ b/ubuntu/install_caffe_and_openpose_JetsonTX2_JetPack3.1.sh
@@ -35,7 +35,7 @@ function executeShInItsFolder {
 
 
 
-executeShInItsFolder "install_caffe_JetsonTX2_JetPack3.1.sh" "./3rdparty/caffe" "../.."
+executeShInItsFolder "install_caffe_JetsonTX2_JetPack3.1.sh" "../3rdparty/caffe" "../.."
 exitIfError
 
 


### PR DESCRIPTION
* Modification of the file ./ubuntu/install_caffe_and_openpose_JetsonTX2_JetPack3.1.sh
* line 38, it needs to go to parent folder first instead of current folder.
* $2 argument "./3rdparty/caffe" has been replaced by "../3rdparty/caffe", that allows the script to find caffe.