### PR TITLE
Fixed link in doc/output.md

### DIFF
--- a/doc/output.md
+++ b/doc/output.md
@@ -121,7 +121,7 @@ There are 3 different keypoint Array<float> elements on this class:
 
 
 ## Reading Saved Results
-We use standard formats (JSON, XML, PNG, JPG, ...) to save our results, so there will be lots of frameworks to read them later, but you might also directly use our functions in [include/openpose/filestream.hpp](../include/openpose/filestream.hpp). In particular, `loadData` (for JSON, XML and YML files) and `loadImage` (for image formats such as PNG or JPG) to load the data into cv::Mat format.
+We use standard formats (JSON, XML, PNG, JPG, ...) to save our results, so there will be lots of frameworks to read them later, but you might also directly use our functions in [include/openpose/filestream/fileStream.hpp](../include/openpose/filestream/fileStream.hpp). In particular, `loadData` (for JSON, XML and YML files) and `loadImage` (for image formats such as PNG or JPG) to load the data into cv::Mat format.
 
 
 


### PR DESCRIPTION
Fixed a broken link on the following page.
https://github.com/CMU-Perceptual-Computing-Lab/openpose/blob/master/doc/output.md