### PR TITLE
Clarify derivative works license in README.md: All derivative work will be owned by CMU

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ OpenPose represents the **first real-time system to jointly detect human body, h
 
 OpenPose is authored by [Gines Hidalgo](https://www.gineshidalgo.com/), [Zhe Cao](http://www.andrew.cmu.edu/user/zhecao), [Tomas Simon](http://www.cs.cmu.edu/~tsimon/), [Shih-En Wei](https://scholar.google.com/citations?user=sFQD3k4AAAAJ&hl=en), [Hanbyul Joo](http://www.cs.cmu.edu/~hanbyulj/), and [Yaser Sheikh](http://www.cs.cmu.edu/~yaser/). Currently, it is being maintained by [Gines Hidalgo](https://www.gineshidalgo.com/) and [Bikramjot Hanzra](https://www.linkedin.com/in/bikz05).
 
-It is freely available for free non-commercial use, and may be redistributed under these conditions. Please, see the [license](LICENSE) for further details. [Interested in a commercial license? Check this link](https://flintbox.com/public/project/47343/). For commercial queries, contact [Yaser Sheikh](http://www.cs.cmu.edu/~yaser/).
+It is freely available for free non-commercial use, and may be redistributed under these conditions. Please note, that all derivative work will become property of Carnegie Mellon University and will be licensed under the same conditions to the contributing author. Please, see the [license](LICENSE) for further details. [Interested in a commercial license? Check this link](https://flintbox.com/public/project/47343/). For commercial queries, contact [Yaser Sheikh](http://www.cs.cmu.edu/~yaser/).
 
 In addition, OpenPose would not be possible without the [CMU Panoptic Studio](http://domedb.perception.cs.cmu.edu/).
 


### PR DESCRIPTION
The title 'Openpose' is misleading. It suggest an open source license such as MIT, Apache or GPL. 

However, the license as documented in [LICENSE](https://github.com/CMU-Perceptual-Computing-Lab/openpose/blob/master/LICENSE) imposes that every derivative work is owned by CMU and then relicensed under the same license to the author of the derivative work: 
See the [DERIVATIVE section](https://github.com/CMU-Perceptual-Computing-Lab/openpose/blob/e086e6fc6a5f4650d5c3a100b8ced8363fd2d099/LICENSE#L20).

I move to clearly inform a potential collaborator about this part of the license.