### PR TITLE
Fix Error: Non valid scaleNetToOutput.

### DIFF
--- a/examples/tutorial_pose/2_extract_pose_or_heatmat_from_image.cpp
+++ b/examples/tutorial_pose/2_extract_pose_or_heatmat_from_image.cpp
@@ -131,7 +131,7 @@ int openPoseTutorialPose2()
     const auto poseKeypoints = poseExtractorPtr->getPoseKeypoints();
     const auto scaleNetToOutput = poseExtractorPtr->getScaleNetToOutput();
     // Step 5 - Render pose
-    poseGpuRenderer.renderPose(outputArray, poseKeypoints, scaleNetToOutput);
+    poseGpuRenderer.renderPose(outputArray, poseKeypoints, scaleInputToOutput, scaleNetToOutput);
     // Step 6 - OpenPose output format to cv::Mat
     auto outputImage = opOutputToCvMat.formatToCvMat(outputArray);
 


### PR DESCRIPTION
Getting Non valid scaleNetToOutput:
if (scaleNetToOutput == -1.f)
                            error("Non valid scaleNetToOutput.", __LINE__, __FUNCTION__, __FILE__);

std::pair<int, std::string> PoseGpuRenderer::renderPose(Array<float>& outputData,
                                                            const Array<float>& poseKeypoints,
                                                            const float scaleInputToOutput,
                                                            const float scaleNetToOutput)
expects 4 parameter.