### PR TITLE
CMake string arguments error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,8 +37,8 @@ if (WIN32)
   # https://gitlab.kitware.com/cmake/cmake/issues/16783
   set(CMAKE_SUPPRESS_REGENERATION ON)
 
-  string (REPLACE "/D_WINDOWS" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
-  string (REPLACE "/DWIN32" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+  string (REPLACE "/D_WINDOWS" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+  string (REPLACE "/DWIN32" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 
   # /GL option causes the code to crash -- fix this
   # sdl flags causes error -- error : unknown attribute \"guard\"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -505,32 +505,6 @@ endif (UNIX AND NOT APPLE)
 
 ### INSTALL
 if (UNIX AND NOT APPLE)
-<<<<<<< HEAD
-  # Install the headers
-  install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/openpose DESTINATION include)
-  install(EXPORT OpenPose DESTINATION lib/OpenPose)
-  if (BUILD_CAFFE)
-    install(DIRECTORY ${CMAKE_BINARY_DIR}/caffe/include/caffe DESTINATION include)
-    install(DIRECTORY ${CMAKE_BINARY_DIR}/caffe/lib/ DESTINATION lib)
-  endif (BUILD_CAFFE)
-
-  # Compute installation prefix relative to this file
-  configure_file(
-    ${CMAKE_SOURCE_DIR}/cmake/OpenPoseConfig.cmake.in
-    ${CMAKE_BINARY_DIR}/cmake/OpenPoseConfig.cmake @ONLY)
-
-  install(FILES ${CMAKE_BINARY_DIR}/cmake/OpenPoseConfig.cmake
-    DESTINATION lib/OpenPose)
-
-  # Uninstall target
-  configure_file(
-    "${CMAKE_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
-    "${CMAKE_BINARY_DIR}/cmake_uninstall.cmake"
-    IMMEDIATE @ONLY)
-
-  add_custom_target(uninstall
-    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
-=======
   if (Caffe_FOUND)
     # Install the headers
     install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/openpose DESTINATION include)
@@ -557,5 +531,4 @@ if (UNIX AND NOT APPLE)
     add_custom_target(uninstall
         COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
   endif (Caffe_FOUND)
->>>>>>> 4d3ba29c88608b00c45612052945844aa19be9b4
 endif (UNIX AND NOT APPLE)


### PR DESCRIPTION
Error message: string sub-command REPLACE requires at least four arguments.
CMake 3.10.1