### PR TITLE
fix datum clone handrectangles bug

### DIFF
--- a/src/openpose/core/datum.cpp
+++ b/src/openpose/core/datum.cpp
@@ -209,7 +209,7 @@ namespace op
             datum.faceRectangles = faceRectangles;
             datum.faceKeypoints = faceKeypoints.clone();
             datum.faceHeatMaps = faceHeatMaps.clone();
-            datum.handRectangles = datum.handRectangles;
+            datum.handRectangles = handRectangles;
             for (auto i = 0u ; i < datum.handKeypoints.size() ; i++)
                 datum.handKeypoints[i] = handKeypoints[i].clone();
             for (auto i = 0u ; i < datum.handKeypoints.size() ; i++)


### PR DESCRIPTION
Fixing small bug in cloning `handRectangles` in `Datums`.