### PR TITLE
include std::map in poseRenderer.hpp

### DIFF
--- a/include/openpose/pose/poseRenderer.hpp
+++ b/include/openpose/pose/poseRenderer.hpp
@@ -1,6 +1,7 @@
 #ifndef OPENPOSE_POSE_POSE_RENDERER_HPP
 #define OPENPOSE_POSE_POSE_RENDERER_HPP
 
+#include <map>
 #include <openpose/core/common.hpp>
 #include <openpose/pose/enumClasses.hpp>
 


### PR DESCRIPTION
I could not find why this started to be a problem but since May the 4th I get compilation errors due to the missing map.
```
poseRenderer.hpp:22:20: error: ‘map’ in namespace ‘std’ does not name a template type
         const std::map<unsigned int, std::string> mPartIndexToName;
                    ^
```