### PR TITLE
[WIP] Add optional hand prediction to python wrapper

### DIFF
--- a/examples/tutorial_python/1_extract_pose.py
+++ b/examples/tutorial_python/1_extract_pose.py
@@ -33,14 +33,17 @@ params["num_gpu_start"] = 0
 params["disable_blending"] = False
 # Ensure you point to the correct path where models are located
 params["default_model_folder"] = dir_path + "/../../../models/"
+# Specify resolution of hand network
+params["hand_net_resolution"] = "368x368"
 # Construct OpenPose object allocates GPU memory
 openpose = OpenPose(params)
+
 
 while 1:
     # Read new image
     img = cv2.imread("../../../examples/media/COCO_val2014_000000000192.jpg")
     # Output keypoints and the image with the human skeleton blended on it
-    keypoints, output_image = openpose.forward(img, True)
+    keypoints, output_image, hands = openpose.forward(img, True, True)
     # Print the human pose keypoints, i.e., a [#people x #keypoints x 3]-dimensional numpy object with the keypoints of all the people on that image
     print(keypoints)
     # Display the image

--- a/python/openpose/openpose.py
+++ b/python/openpose/openpose.py
@@ -106,11 +106,13 @@ class OpenPose(object):
         ----------
         image : color image of type ndarray
         display : If set to true, we return both the pose and an annotated image for visualization
+        hands : If set to true, also predict and return hand keypoints.
 
         Returns
         -------
         array: ndarray of human 2D poses [People * BodyPart * XYConfidence]
         displayImage : image for visualization
+        hands : ndarray of hands correspodning to the poses. [2 * People * HandParts * XYConfidence]
         """
         shape = image.shape
         displayImage = np.zeros(shape=(image.shape), dtype=np.uint8)


### PR DESCRIPTION
Added hand prediction to the python wrapper, but only to the `forward(...)` method. I haven't added hand prediction to `poseFromHM(...)` as I'm personally not interested in it.  This can maybe serve as a starting point for anyone who wishes to add that as well.

Possible issues/improvements:
* Does not concatenate pose keypoints with hand keypoints, instead returns them as separate arrays, which may not be expected behaviour.
* The copying of the hand array from `std::array` to python.  Wasn't sure how to do this in a good way, and I am not pleased with how it looks.  However, I'm not sure how to do it cleanly. 

I am adding this as a PR more as a starting point for further work on adding hand detection to the python wrapper than as a feature-complete PR. 

Appreciate any feedback! :smile: 