### PR TITLE
fixed issue #814

### DIFF
--- a/cmake/OpenPoseConfig.cmake.in
+++ b/cmake/OpenPoseConfig.cmake.in
@@ -5,12 +5,12 @@ get_filename_component(_prefix "${_dir}/../.." ABSOLUTE)
 # Import the targets
 include("${_prefix}/lib/OpenPose/OpenPose.cmake")
 if (@BUILD_CAFFE@)
-  set(Caffe_INCLUDE_DIRS "${_prefix}/include/caffe")
+  set(Caffe_INCLUDE_DIRS "${_prefix}/include/")
   # set(Caffe_LIBS "${_prefix}/lib/libcaffe.so")
 endif (@BUILD_CAFFE@)
 
 # Report other information
-set(OpenPose_INCLUDE_DIRS "${_prefix}/include/openpose")
+set(OpenPose_INCLUDE_DIRS "${_prefix}/include/")
 set(OpenPose_VERSION_MAJOR @OpenPose_VERSION_MAJOR@)
 set(OpenPose_VERSION_MINOR @OpenPose_VERSION_MINOR@)
 set(OpenPose_VERSION_PATCH @OpenPose_VERSION_PATCH@)


### PR DESCRIPTION
Fixed the issue "No such file or directory" When using openpose as an external library via cmake. Altered the library path in OpenPoseConfig.cmake.in.
For reference see issue #814 