### PR TITLE
Adapt default resolution to normal graphic cards

### DIFF
--- a/examples/tutorial_python/1_extract_pose.py
+++ b/examples/tutorial_python/1_extract_pose.py
@@ -32,13 +32,13 @@ params["render_threshold"] = 0.05
 params["num_gpu_start"] = 0
 params["disable_blending"] = False
 # Ensure you point to the correct path where models are located
-params["default_model_folder"] = dir_path + "/../../../models/"
+params["default_model_folder"] = dir_path + "/../../models/"
 # Construct OpenPose object allocates GPU memory
 openpose = OpenPose(params)
 
 while 1:
     # Read new image
-    img = cv2.imread("../../../examples/media/COCO_val2014_000000000192.jpg")
+    img = cv2.imread("../../examples/media/COCO_val2014_000000000192.jpg")
     # Output keypoints and the image with the human skeleton blended on it
     keypoints, output_image = openpose.forward(img, True)
     # Print the human pose keypoints, i.e., a [#people x #keypoints x 3]-dimensional numpy object with the keypoints of all the people on that image

--- a/examples/tutorial_python/2_pose_from_heatmaps.py
+++ b/examples/tutorial_python/2_pose_from_heatmaps.py
@@ -23,7 +23,7 @@ except:
     raise Exception('Error: OpenPose library could not be found. Did you enable `BUILD_PYTHON` in CMake and have this Python script in the right folder?')
 
 # Params for change
-defRes = 736
+defRes = 288
 scales = [1,0.5]
 class Param:
     caffemodel = dir_path + "/../../models/pose/body_25/pose_iter_584000.caffemodel"

--- a/examples/tutorial_python/2_pose_from_heatmaps.py
+++ b/examples/tutorial_python/2_pose_from_heatmaps.py
@@ -26,8 +26,8 @@ except:
 defRes = 736
 scales = [1,0.5]
 class Param:
-    caffemodel = dir_path + "/../../../models/pose/body_25/pose_iter_584000.caffemodel"
-    prototxt = dir_path + "/../../../models/pose/body_25/pose_deploy.prototxt"
+    caffemodel = dir_path + "/../../models/pose/body_25/pose_iter_584000.caffemodel"
+    prototxt = dir_path + "/../../models/pose/body_25/pose_deploy.prototxt"
 
 # Load OpenPose object and Caffe Nets
 params = dict()
@@ -41,7 +41,7 @@ params["scale_number"] = len(scales)
 params["render_threshold"] = 0.05
 params["num_gpu_start"] = 0
 params["disable_blending"] = False
-params["default_model_folder"] = dir_path + "/../../../models/"
+params["default_model_folder"] = dir_path + "/../../models/"
 openpose = OpenPose(params)
 caffe.set_mode_gpu()
 caffe.set_device(0)
@@ -90,7 +90,7 @@ def func(frame):
     return frame
 
 
-img = cv2.imread(dir_path + "/../../../examples/media/COCO_val2014_000000000192.jpg")
+img = cv2.imread(dir_path + "/../../examples/media/COCO_val2014_000000000192.jpg")
 frame = func(img)
 while 1:
     cv2.imshow("output", frame)


### PR DESCRIPTION
The default resolution of 736 triggers a Caffe Out-Of-Memory.
> F0909 syncedmem.cpp:71] Check failed: error == cudaSuccess (2 vs. 0)  out of memory
... even on a modern graphic card (GeForce GTX 1050, 4GB)

Try to reduce resolution to something that'd run for "most" people.

Only hunk about "`defRes = 288`" is relevant.
(but depends upon #824 in order to avoid conflicts)