### PR TITLE
Added virtual destructor to base poseRenderer header

### DIFF
--- a/include/openpose/pose/poseRenderer.hpp
+++ b/include/openpose/pose/poseRenderer.hpp
@@ -12,6 +12,8 @@ namespace op
     public:
         PoseRenderer(const PoseModel poseModel);
 
+        virtual ~PoseRenderer() = default;
+
         virtual void initializationOnThread(){};
 
         virtual std::pair<int, std::string> renderPose(Array<float>& outputData, const Array<float>& poseKeypoints,

--- a/include/openpose/pose/poseRenderer.hpp
+++ b/include/openpose/pose/poseRenderer.hpp
@@ -12,7 +12,7 @@ namespace op
     public:
         PoseRenderer(const PoseModel poseModel);
 
-        virtual ~PoseRenderer() = default;
+        virtual ~PoseRenderer();
 
         virtual void initializationOnThread(){};
 

--- a/src/openpose/pose/poseRenderer.cpp
+++ b/src/openpose/pose/poseRenderer.cpp
@@ -57,4 +57,6 @@ namespace op
         mPartIndexToName{createPartToName(poseModel)}
     {
     }
+
+    PoseRenderer::~PoseRenderer(){}
 }

--- a/src/openpose/pose/poseRenderer.cpp
+++ b/src/openpose/pose/poseRenderer.cpp
@@ -58,5 +58,7 @@ namespace op
     {
     }
 
-    PoseRenderer::~PoseRenderer(){}
+    PoseRenderer::~PoseRenderer()
+    {
+    }
 }


### PR DESCRIPTION
This allows poseGpuRenderer and poseCpuRenderer to release their resources when using only poseRenderer as an interface.