### PR TITLE
Fix in multi-view (camera Leave One Out)

### DIFF
--- a/src/openpose/3d/poseTriangulation.cpp
+++ b/src/openpose/3d/poseTriangulation.cpp
@@ -196,7 +196,7 @@ namespace op
                         && projectionErrorSubset < 1.1 * projectionError)
                     {
                         bestReprojectionIndex = -1;
-                        break;
+                        continue;
                     }
                     // Save maximum
                     if (bestReprojection > projectionErrorSubset)
@@ -212,6 +212,7 @@ namespace op
                     cameraMatricesFinal.erase(cameraMatricesFinal.begin() + bestReprojectionIndex);
                     pointsOnEachCameraFinal.erase(pointsOnEachCameraFinal.begin() + bestReprojectionIndex);
                 }
+		projectionError = bestReprojection; // updates the projection error with the best found after camera removal
             }
 
             #ifdef USE_CERES


### PR DESCRIPTION
- Substituted a "break" with a "continue" so that if the reprojection error does not change removing camera "k" it keeps on exploring with camera "k+1" and so on.

- Returns new bestReprojectionError after removing the k-th camera