### PR TITLE
Fix bug in KeepTopNPeople

### DIFF
--- a/src/openpose/core/keepTopNPeople.cpp
+++ b/src/openpose/core/keepTopNPeople.cpp
@@ -17,7 +17,7 @@ namespace op
         try
         {
             // Remove people if #people > mNumberPeopleMax
-            if (peopleArray.getVolume() > (unsigned int)mNumberPeopleMax && mNumberPeopleMax > 0)
+            if (peopleArray.getSize(0) > (unsigned int)mNumberPeopleMax && mNumberPeopleMax > 0)
             {
                 // Sanity checks
                 if (poseScores.getVolume() != (unsigned int) poseScores.getSize(0))


### PR DESCRIPTION
This fixes a bug where the volume of of the peopleArray was being used instead of size of the first dimension. `getVolume()` returns all dimensions multiplied by each other, so for a `personArray` with a single person (using the BODY_25 model) `getVolume()` will return 75 (1 * 25 * 3) whereas `getSize(0)` will return 1 which is what needs to be compared to the `mNumberPeopleMax`, a variable containing the number of people to allow. 

The bug would manifest itself as an array out of bounds error on line 39 `poseScoresSorted[mNumberPeopleMax-1];` ,which assumes that there are always more people in the `peopleArray` than `mNumberPeopleMax`, which is not always the case because of the error (using volume instead of size) in the guard above.