### PR TITLE
use bash shebang in cuda installation script

### DIFF
--- a/ubuntu/install_cuda.sh
+++ b/ubuntu/install_cuda.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 ubuntu_version="$(lsb_release -r)"
 sudo apt-get update && sudo apt-get install wget -y --no-install-recommends
 if [[ $ubuntu_version == *"14."* ]]; then

--- a/ubuntu/install_cudnn.sh
+++ b/ubuntu/install_cudnn.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Install cuDNN 5.1
 ubuntu_version="$(lsb_release -r)"
 CUDNN_URL="http://developer.download.nvidia.com/compute/redist/cudnn/v5.1/cudnn-8.0-linux-x64-v5.1.tgz"


### PR DESCRIPTION
When calling the script on a default install Ubuntu 16.04 it will error
out with

  ubuntu/install_cuda.sh: 3: ubuntu/install_cuda.sh: [[: not found

With a shebang we will get full bash functionality.