### PR TITLE
Fix call to getPoseMaxPeaks

### DIFF
--- a/python/openpose/_openpose.cpp
+++ b/python/openpose/_openpose.cpp
@@ -188,7 +188,7 @@ public:
         resizeAndMergeCaffe->Reshape(caffeNetOutputBlobs, { heatMapsBlob.get() },
             op::getPoseNetDecreaseFactor(poseModel), 1.f / 1.f, true,
             0);
-        nmsCaffe->Reshape({ heatMapsBlob.get() }, { peaksBlob.get() }, op::getPoseMaxPeaks(poseModel),
+        nmsCaffe->Reshape({ heatMapsBlob.get() }, { peaksBlob.get() }, op::getPoseMaxPeaks(),
             op::getPoseNumberBodyParts(poseModel), 0);
         bodyPartConnectorCaffe->Reshape({ heatMapsBlob.get(), peaksBlob.get() });
 


### PR DESCRIPTION
A [recent commit](https://github.com/CMU-Perceptual-Computing-Lab/openpose/commit/dcc0c51348f29eeb468a0f6df764ded66e84a8bb) changed the `getPoseMaxPeaks` interface, breaking the python module and causing linking to fail in the final steps of `make`. This PR fixes it to use the new, unparameterized interface, allowing linking to properly complete.