### PR TITLE
Include the handling of Protobuf, who's includes are transitively required via Caffe, in the build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -368,11 +368,9 @@ if (UNIX OR APPLE)
     include(cmake/Cuda.cmake)
     find_package(CuDNN)
   endif (${GPU_MODE} MATCHES "CUDA")
-  find_package(GFlags)
-  find_package(Glog)
-
-  # Caffe has transitive dependencies on Protobuf
-  find_package(Protobuf REQUIRED)
+  find_package(GFlags) # For Caffe and OpenPose
+  find_package(Glog) # For Caffe
+  find_package(Protobuf REQUIRED) # For Caffe
 
   if (OpenCV_CONFIG_FILE)
     include (${OpenCV_CONFIG_FILE})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,6 +376,9 @@ if (UNIX OR APPLE)
 
   if (OpenCV_CONFIG_FILE)
     include (${OpenCV_CONFIG_FILE})
+  # Allow explicitly setting the OpenCV includes and libs
+  elseif (OpenCV_INCLUDE_DIRS AND OpenCV_LIBS)
+    set(OpenCV_FOUND 1)
   elseif (OpenCV_INCLUDE_DIRS AND OpenCV_LIBS_DIR)
     file(GLOB_RECURSE OpenCV_LIBS "${OpenCV_LIBS_DIR}*.so")
     set(OpenCV_FOUND 1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -370,6 +370,10 @@ if (UNIX OR APPLE)
   endif (${GPU_MODE} MATCHES "CUDA")
   find_package(GFlags)
   find_package(Glog)
+
+  # Caffe has transitive dependencies on Protobuf
+  find_package(Protobuf REQUIRED)
+
   if (OpenCV_CONFIG_FILE)
     include (${OpenCV_CONFIG_FILE})
   elseif (OpenCV_INCLUDE_DIRS AND OpenCV_LIBS_DIR)
@@ -754,6 +758,7 @@ endif (UNIX OR APPLE)
 # Specify the include directories
 include_directories(
   include
+  ${Protobuf_INCLUDE_DIRS}
   ${GFLAGS_INCLUDE_DIR}
   ${GLOG_INCLUDE_DIR}
   ${OpenCV_INCLUDE_DIRS})


### PR DESCRIPTION

This allows for the ability to handle Protobuf versions more flexibly. 

I'm currently am on Ubuntu 18.04 which has Protobuf 3.0.0 as a base system requirement of a few other packages. When building OpenPose I have a separate build of Protobuf (version 3.6.0) that's compliant with the version of Tensorflow (version 1.12.0) that's also being built. This adds the ability to direct the OpenPose build to use the non-system installed Protobuf, which is already the case for Caffe, OpenCV, and Tensorflow.

If this isn't the correct way to handle this then let me know and I'll rework it. If you decide it's not appropriate please let me, I'll need to replace the main system's protobuf.

Thanks.