### PR TITLE
Change FindCuDNN.cmake to also check more env variables

### DIFF
--- a/cmake/Modules/FindCuDNN.cmake
+++ b/cmake/Modules/FindCuDNN.cmake
@@ -2,12 +2,12 @@ set(CUDNN_ROOT "" CACHE PATH "CUDNN root folder")
 set(CUDNN_LIB_NAME "libcudnn.so")
 
 find_path(CUDNN_INCLUDE cudnn.h
-    PATHS ${CUDNN_ROOT} $ENV{CUDNN_ROOT} ${CUDA_TOOLKIT_INCLUDE}
+    PATHS ${CUDNN_ROOT} $ENV{CUDNN_ROOT} ${CUDA_TOOLKIT_INCLUDE} $ENV{CUDNN_LIBRARY_DIR}
     DOC "Path to cuDNN include directory." )
 
 get_filename_component(__libpath_hist ${CUDA_CUDART_LIBRARY} PATH)
 find_library(CUDNN_LIBRARY NAMES ${CUDNN_LIB_NAME}
-    PATHS ${CUDNN_ROOT} $ENV{CUDNN_ROOT} ${CUDNN_INCLUDE} ${__libpath_hist} ${__libpath_hist}/../lib
+    PATHS ${CUDNN_ROOT} $ENV{CUDNN_ROOT} ${CUDNN_INCLUDE} ${__libpath_hist} ${__libpath_hist}/../lib $ENV{CUDNN_LIBRARY_DIR}
     DOC "Path to cuDNN library.")
 
 if(CUDNN_INCLUDE AND CUDNN_LIBRARY)


### PR DESCRIPTION
Now the variables ENV{CUDNN_LIBRARY_DIR} and ENV{CUDNN_LIBRARY_DIR} are checked, too.  
This helps for custom setups with local installs.