### PR TITLE
Allow build against OpenCV 4.

### DIFF
--- a/src/openpose/3d/cameraParameterReader.cpp
+++ b/src/openpose/3d/cameraParameterReader.cpp
@@ -1,6 +1,8 @@
-﻿
-#include <opencv2/calib3d.hpp> // cv::initUndistortRectifyMap in OpenCV 4
-#include <opencv2/imgproc/imgproc.hpp> // cv::undistort, cv::initUndistortRectifyMap (in OpenCV 3)
+#include <openpose/core/macros.hpp> // OPEN_CV_IS_4_OR_HIGHER
+#ifdef OPEN_CV_IS_4_OR_HIGHER
+    #include <opencv2/calib3d.hpp> // cv::initUndistortRectifyMap in OpenCV 4
+#endif
+#include <opencv2/imgproc/imgproc.hpp> // cv::initUndistortRectifyMap (OpenCV <= 3), cv::undistort
 #include <openpose/filestream/fileStream.hpp>
 #include <openpose/utilities/fileSystem.hpp>
 #include <openpose/3d/cameraParameterReader.hpp>

--- a/src/openpose/3d/cameraParameterReader.cpp
+++ b/src/openpose/3d/cameraParameterReader.cpp
@@ -1,4 +1,6 @@
-﻿#include <opencv2/imgproc/imgproc.hpp> // cv::undistort, cv::initUndistortRectifyMap
+﻿
+#include <opencv2/calib3d.hpp> // cv::initUndistortRectifyMap in OpenCV 4
+#include <opencv2/imgproc/imgproc.hpp> // cv::undistort, cv::initUndistortRectifyMap (in OpenCV 3)
 #include <openpose/filestream/fileStream.hpp>
 #include <openpose/utilities/fileSystem.hpp>
 #include <openpose/3d/cameraParameterReader.hpp>


### PR DESCRIPTION
This allows the build against both OpenCV 3 and OpenCV 4.

cv::initUndistortRectifyMap was moved from imgproc.hpp to calib3d.hpp.