### PR TITLE
Changed exit behaviour in python examples

### DIFF
--- a/examples/tutorial_api_python/1_body_from_image.py
+++ b/examples/tutorial_api_python/1_body_from_image.py
@@ -64,4 +64,7 @@ opWrapper.emplaceAndPop([datum])
 print("Body keypoints: \n" + str(datum.poseKeypoints))
 while 1:
     cv2.imshow("win", datum.cvOutputData)
-    cv2.waitKey(15)
+    if cv2.waitKey(15) & 0xFF == ord('q'):
+        break
+
+cv2.destroyAllWindows()

--- a/examples/tutorial_api_python/2_whole_body_from_image.py
+++ b/examples/tutorial_api_python/2_whole_body_from_image.py
@@ -69,4 +69,7 @@ print("Left hand keypoints: \n" + str(datum.handKeypoints[0]))
 print("Right hand keypoints: \n" + str(datum.handKeypoints[1]))
 while 1:
     cv2.imshow("win", datum.cvOutputData)
-    cv2.waitKey(15)
+    if cv2.waitKey(15) & 0xFF == ord('q'):
+        break
+
+cv2.destroyAllWindows()

--- a/examples/tutorial_api_python/3_heatmaps_from_image.py
+++ b/examples/tutorial_api_python/3_heatmaps_from_image.py
@@ -78,6 +78,9 @@ while 1:
     heatmap = cv2.applyColorMap(heatmap, cv2.COLORMAP_JET)
     combined = cv2.addWeighted(outputImageF, 0.5, heatmap, 0.5, 0)
     cv2.imshow("win", combined)
-    cv2.waitKey(-1)
+    if cv2.waitKey(-1) & 0xFF == ord('q'):
+        break
     counter += 1
     counter = counter % num_maps
+
+cv2.destroyAllWindows()


### PR DESCRIPTION
Added 'q' as a 'quit' key for easier exit and destroyed cv windows at the end of the loop to avoid hanging. 