### PR TITLE
Restructured dependencies to be independent from build scripts.

### DIFF
--- a/scripts/osx/deps-core.txt
+++ b/scripts/osx/deps-core.txt
@@ -1,0 +1,9 @@
+openblas
+snappy 
+leveldb 
+gflags 
+glog 
+szip 
+lmdb
+hdf5 
+opencv

--- a/scripts/osx/deps-rem.txt
+++ b/scripts/osx/deps-rem.txt
@@ -1,0 +1,4 @@
+protobuf
+boost
+cmake
+viennacl

--- a/scripts/osx/install_deps.sh
+++ b/scripts/osx/install_deps.sh
@@ -1,7 +1,6 @@
 brew install openblas
 brew install -vd snappy leveldb gflags glog szip lmdb
 # need the homebrew science source for OpenCV and hdf5
-brew tap homebrew/science
 brew install hdf5 opencv
 # with Python pycaffe needs dependencies built from source
 #brew install --build-from-source --with-python -vd protobuf

--- a/scripts/osx/install_deps.sh
+++ b/scripts/osx/install_deps.sh
@@ -1,12 +1,7 @@
-brew install openblas
-brew install -vd snappy leveldb gflags glog szip lmdb
-# need the homebrew science source for OpenCV and hdf5
-brew install hdf5 opencv
+cat scripts/osx/deps-core.txt | xargs brew install -vd
 # with Python pycaffe needs dependencies built from source
 #brew install --build-from-source --with-python -vd protobuf
 #brew install --build-from-source -vd boost boost-python
 # without Python the usual installation suffices
-brew install protobuf boost
-brew install cmake
-brew install viennacl
+cat scripts/osx/deps-rem.txt | xargs brew install -vd
 sudo pip install -r scripts/osx/python-requirements.txt

--- a/scripts/osx/install_deps.sh
+++ b/scripts/osx/install_deps.sh
@@ -10,5 +10,4 @@ brew install hdf5 opencv
 brew install protobuf boost
 brew install cmake
 brew install viennacl
-sudo pip install numpy
-sudo pip install opencv-python
+sudo pip install -r scripts/osx/python-requirements.txt

--- a/scripts/osx/python-requirements.txt
+++ b/scripts/osx/python-requirements.txt
@@ -1,2 +1,2 @@
-numpy==*
-opencv-python==*
+numpy
+opencv-python

--- a/scripts/osx/python-requirements.txt
+++ b/scripts/osx/python-requirements.txt
@@ -1,0 +1,2 @@
+numpy==*
+opencv-python==*

--- a/scripts/ubuntu/deps-core.txt
+++ b/scripts/ubuntu/deps-core.txt
@@ -1,0 +1,1 @@
+build-essential

--- a/scripts/ubuntu/deps-gen.txt
+++ b/scripts/ubuntu/deps-gen.txt
@@ -1,0 +1,7 @@
+libatlas-base-dev 
+libprotobuf-dev 
+libleveldb-dev 
+libsnappy-dev 
+libhdf5-serial-dev 
+protobuf-compiler
+libboost-all-dev

--- a/scripts/ubuntu/deps-opencl.txt
+++ b/scripts/ubuntu/deps-opencl.txt
@@ -1,0 +1,3 @@
+opencl-headers 
+ocl-icd-opencl-dev
+libviennacl-dev

--- a/scripts/ubuntu/deps-python2.txt
+++ b/scripts/ubuntu/deps-python2.txt
@@ -1,0 +1,2 @@
+python-setuptools 
+python-dev

--- a/scripts/ubuntu/deps-python3.txt
+++ b/scripts/ubuntu/deps-python3.txt
@@ -1,0 +1,3 @@
+python3-setuptools 
+python3-dev 
+python3-pip

--- a/scripts/ubuntu/deps-rem.txt
+++ b/scripts/ubuntu/deps-rem.txt
@@ -1,0 +1,3 @@
+libgflags-dev 
+libgoogle-glog-dev 
+liblmdb-dev

--- a/scripts/ubuntu/install_deps.sh
+++ b/scripts/ubuntu/install_deps.sh
@@ -2,24 +2,22 @@
 
 ### INSTALL PREREQUISITES
 
-# Basic
-sudo apt-get --assume-yes update
-sudo apt-get --assume-yes install build-essential
+sudo apt-get -y update
+
+# Core
+cat deps-core.txt | xargs sudo apt-get -y --no-install-recommends install
 # General dependencies
-sudo apt-get --assume-yes install libatlas-base-dev libprotobuf-dev libleveldb-dev libsnappy-dev libhdf5-serial-dev protobuf-compiler
-sudo apt-get --assume-yes install --no-install-recommends libboost-all-dev
+cat deps-gen.txt | xargs sudo apt-get -y --no-install-recommends install
 # Remaining dependencies, 14.04
-sudo apt-get --assume-yes install libgflags-dev libgoogle-glog-dev liblmdb-dev
+cat deps-rem.txt | xargs sudo apt-get -y --no-install-recommends install
 # Python2 libs
-sudo apt-get --assume-yes install python-setuptools python-dev build-essential
+cat deps-python2.txt | xargs sudo apt-get -y --no-install-recommends install
 sudo easy_install pip
-sudo -H pip install --upgrade numpy protobuf opencv-python
+sudo -H pip install --upgrade -r python-requirements.txt
 # Python3 libs
-sudo apt-get --assume-yes install python3-setuptools python3-dev build-essential
-sudo apt-get --assume-yes install python3-pip
-sudo -H pip3 install --upgrade numpy protobuf opencv-python
+cat deps-python3.txt | xargs sudo apt-get -y --no-install-recommends install
+sudo -H pip3 install --upgrade -r python-requirements.txt
 # OpenCV 2.4 -> Added as option
-# # sudo apt-get --assume-yes install libopencv-dev
+# # sudo apt-get -y install libopencv-dev
 # OpenCL Generic
-sudo apt-get --assume-yes install opencl-headers ocl-icd-opencl-dev
-sudo apt-get --assume-yes install libviennacl-dev
+cat deps-opencl.txt | xargs sudo apt-get -y --no-install-recommends install

--- a/scripts/ubuntu/install_deps.sh
+++ b/scripts/ubuntu/install_deps.sh
@@ -5,19 +5,19 @@
 sudo apt-get -y update
 
 # Core
-cat deps-core.txt | xargs sudo apt-get -y --no-install-recommends install
+cat scripts/ubuntu/deps-core.txt | xargs sudo apt-get -y --no-install-recommends install
 # General dependencies
-cat deps-gen.txt | xargs sudo apt-get -y --no-install-recommends install
+cat scripts/ubuntu/deps-gen.txt | xargs sudo apt-get -y --no-install-recommends install
 # Remaining dependencies, 14.04
-cat deps-rem.txt | xargs sudo apt-get -y --no-install-recommends install
+cat scripts/ubuntu/deps-rem.txt | xargs sudo apt-get -y --no-install-recommends install
 # Python2 libs
-cat deps-python2.txt | xargs sudo apt-get -y --no-install-recommends install
+cat scripts/ubuntu/deps-python2.txt | xargs sudo apt-get -y --no-install-recommends install
 sudo easy_install pip
-sudo -H pip install --upgrade -r python-requirements.txt
+sudo -H pip install --upgrade -r scripts/ubuntu/python-requirements.txt
 # Python3 libs
-cat deps-python3.txt | xargs sudo apt-get -y --no-install-recommends install
-sudo -H pip3 install --upgrade -r python-requirements.txt
+cat scripts/ubuntu/deps-python3.txt | xargs sudo apt-get -y --no-install-recommends install
+sudo -H pip3 install --upgrade -r scripts/ubuntu/python-requirements.txt
 # OpenCV 2.4 -> Added as option
 # # sudo apt-get -y install libopencv-dev
 # OpenCL Generic
-cat deps-opencl.txt | xargs sudo apt-get -y --no-install-recommends install
+cat scripts/ubuntu/deps-opencl.txt | xargs sudo apt-get -y --no-install-recommends install

--- a/scripts/ubuntu/python-requirements.txt
+++ b/scripts/ubuntu/python-requirements.txt
@@ -1,3 +1,3 @@
-numpy==*
-protobuf==*
-opencv-python==*
+numpy
+protobuf
+opencv-python

--- a/scripts/ubuntu/python-requirements.txt
+++ b/scripts/ubuntu/python-requirements.txt
@@ -1,0 +1,3 @@
+numpy==*
+protobuf==*
+opencv-python==*


### PR DESCRIPTION
This is meant to solve a couple of issues.

The first is that tracking down dependencies (especially when they change) can be slightly arduous since they're built into the build scripts. 

The second is that if you're doing an automated build using OpenPose, say, by building a docker image, then the only current courses of action are to either run the install_deps.sh script or manually copy the dependencies. This is inconvenient because you might not want all the dependencies (for example, Python2) and you also might only want to track changed dependencies.

I've proposed splitting the dependencies into numerous text files while maintaining the segregation they had in the build script.

Some of these can probably be consolidated - for example, core only contains build-essential for now.

The build_deps.sh script has been updated to reflect this change. In order to change dependencies, one need only add or remove lines from the appropriate package list. This has also been done for the python dependencies (which are uniform across python2 and python3, negating the need for two separate files).

This isn't a terribly clean solution due to the sheer number of dependency files, but we can probably reduce the amount and reorganize them (perhaps into a dependencies folder) so that they're easier to work with for both people building and running the script, and people building and running the software using a more custom configuration.
