### PR TITLE
Ubuntu - find cudnn

### DIFF
--- a/cmake/Modules/FindCuDNN.cmake
+++ b/cmake/Modules/FindCuDNN.cmake
@@ -2,12 +2,12 @@ set(CUDNN_ROOT "" CACHE PATH "CUDNN root folder")
 set(CUDNN_LIB_NAME "libcudnn.so")
 
 find_path(CUDNN_INCLUDE cudnn.h
-    PATHS ${CUDNN_ROOT} $ENV{CUDNN_ROOT} ${CUDA_TOOLKIT_INCLUDE}
+    PATHS ${CUDNN_ROOT} $ENV{CUDNN_ROOT} ${CUDA_TOOLKIT_INCLUDE} /usr/local/cuda/include
     DOC "Path to cuDNN include directory." )
 
 get_filename_component(__libpath_hist ${CUDA_CUDART_LIBRARY} PATH)
 find_library(CUDNN_LIBRARY NAMES ${CUDNN_LIB_NAME}
-    PATHS ${CUDNN_ROOT} $ENV{CUDNN_ROOT} ${CUDNN_INCLUDE} ${__libpath_hist} ${__libpath_hist}/../lib
+    PATHS ${CUDNN_ROOT} $ENV{CUDNN_ROOT} ${CUDNN_INCLUDE} ${__libpath_hist} ${__libpath_hist}/../lib /usr/local/cuda/lib64
     DOC "Path to cuDNN library.")
 
 if(CUDNN_INCLUDE AND CUDNN_LIBRARY)


### PR DESCRIPTION
I'm on ubuntu 18.04 LTS 
https://gist.github.com/johndpope/c68a29ca90703394d7c95142be03bafb
I installed the cudnn from nvidia - the script says to install older verison 8 - but this code above finds v9.