### PR TITLE
Fix sanity check in wrapper

### DIFF
--- a/include/openpose/wrapper/wrapperAuxiliary.hpp
+++ b/include/openpose/wrapper/wrapperAuxiliary.hpp
@@ -148,7 +148,7 @@ namespace op
             const auto renderHandGpu = wrapperStructHand.enable && renderModeHand == RenderMode::Gpu;
 
             // Check no wrong/contradictory flags enabled
-            const auto userInputAndPreprocessingWsEmpty = userInputWs.empty();
+            const auto userInputAndPreprocessingWsEmpty = userInputWs.empty() && userPreProcessingWs.empty();
             const auto userOutputWsEmpty = userOutputWs.empty();
             wrapperConfigureSanityChecks(
                 wrapperStructPose, wrapperStructFace, wrapperStructHand, wrapperStructExtra, wrapperStructInput,


### PR DESCRIPTION
The variable `userInputAndPreprocessingWsEmpty` but only checks if `userInputWs` is empty, and not `userPreProcessingWs`. This results is premature termination during sanity checks at [wrapperAuxiliary.cpp:115](https://github.com/CMU-Perceptual-Computing-Lab/openpose/blob/master/src/openpose/wrapper/wrapperAuxiliary.cpp#L115) in some scenarios.

For example: The user wants to do hand pose extraction using their own hand rectangles. They use the default producer but supply their own hand rectangles with a pre-processor worker. The above sanity check will erroneously fail, even though hand rectangles are supplied. I can provide code for a minimal repro if needed.