### PR TITLE
Command consistency checks and error fixing in mac build instructions

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -172,11 +172,18 @@ Note: If you prefer to use your own custom Caffe or OpenCV versions, see [Custom
 
 
 ### OpenPose Building
-#### Ubuntu and Mac
-Finally, build the project by running the following commands.
+#### Ubuntu
+Build the project by running the following commands.
 ```
 cd build/
 make -j`nproc`
+```
+
+#### Mac
+Build the project by running the following commands.
+```
+cd build/
+make -j`sysctl -n hw.physicalcpu`
 ```
 
 #### Windows

--- a/doc/prerequisites.md
+++ b/doc/prerequisites.md
@@ -48,7 +48,7 @@ git submodule update --init --recursive --remote
             - Follow the Nvidia website installation instructions. Make sure to enable the symbolic link in `usr/local/cuda` to minimize potential future errors.
     3. **cuDNN**:
         - Ubuntu 14 or 16 ([**cuDNN 5.1**](https://developer.nvidia.com/rdp/cudnn-archive) **or 7.2**): Run `sudo ./scripts/ubuntu/install_cudnn.sh` (if Ubuntu 16 or 14 and for Graphic cards up to 10XX) or alternatively download and install it from their website.
-        - Ubuntu 18 ([**cuDNN 7.2**](https://developer.nvidia.com/cudnn)): Download and install it from the [Nvidia website](https://developer.nvidia.com/cudnn).
+        - Ubuntu 18 ([**cuDNN 7.5**](https://developer.nvidia.com/cudnn)): Download and install it from the [Nvidia website](https://developer.nvidia.com/cudnn).
         - In order to manually install it (any version), just unzip it and copy (merge) the contents on the CUDA folder, usually `/usr/local/cuda/` in Ubuntu and `C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v8.0` in Windows.
 5. AMD GPU version prerequisites:
     1. Ubuntu 14 or 16:
@@ -57,7 +57,7 @@ git submodule update --init --recursive --remote
     2. Ubuntu 18: Not tested and not officially supported. Try at your risk.
 6. Install **Caffe, OpenCV, and Caffe prerequisites**:
     - Caffe prerequisites: By default, OpenPose uses Caffe under the hood. If you have not used Caffe previously, install its dependencies by running `sudo bash ./scripts/ubuntu/install_deps_and_cuda.sh` (if Ubuntu 16 or 14 and for Graphic cards up to 10XX) or run `sudo bash ./scripts/ubuntu/install_deps.sh` after installing your desired CUDA and cuDNN versions.
-    - OpenCV must be already installed on your machine. It can be installed with `apt-get install libopencv-dev`. You can also use your own compiled OpenCV version.
+    - OpenCV must be already installed on your machine. It can be installed with `sudo apt-get install libopencv-dev`. You can also use your own compiled OpenCV version.
 7. **Eigen prerequisite** (optional, only required for some specific extra functionality, such as extrinsic camera calibration):
     - If you enable the `WITH_EIGEN` flag when running CMake, you must have Eigen already installed in your system. Note that [Eigen <= 3.3.6 is not supported by CUDA >=9.1](https://bitbucket.org/eigen/eigen/commits/034b6c3e101792a3cc3ccabd9bfaddcabe85bb58?at=default). In order to install it, you can perform any of the 3 following options (but only 1 of them!), while making sure that Eigen version is compatible with CUDA:
         1. Do not do anything if you set the `WITH_EIGEN` flag to `BUILD`, CMake will automatically download Eigen. Alternatively, you might prefer to download it manually:


### PR DESCRIPTION
prerequisites.md
- sudo across all apt commands in ubuntu
- bump cudnn 7.2 -> 7.5 for 18.04 to get on par with current

installation.md
- `nproc` is not available on MacOS, uses `sysctl -n hw.logicalcpu` to return logical cores instead