### PR TITLE
Changes nproc for mac to hw.logicalcpu where applicable

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -180,7 +180,7 @@ make -j`nproc`
 ```
 
 #### Mac
-Build the project by running the following commands.
+Build the project by running the following commands (note that Mac provides both `logicalcpu` and `physicalcpu`, but we want the logical number for maximum speed).
 ```
 cd build/
 make -j`sysctl -n hw.logicalcpu`

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -103,7 +103,7 @@ We add links to some community-based work based on OpenPose. Note: We do not sup
 The first step is to clone the OpenPose repository.
 
 1. Windows: You might use [GitHub Desktop](https://desktop.github.com/).
-2. Ubuntu:
+2. Ubuntu/Mac:
 ```bash
 git clone https://github.com/CMU-Perceptual-Computing-Lab/openpose
 ```
@@ -183,7 +183,7 @@ make -j`nproc`
 Build the project by running the following commands.
 ```
 cd build/
-make -j`sysctl -n hw.physicalcpu`
+make -j`sysctl -n hw.logicalcpu`
 ```
 
 #### Windows

--- a/examples/user_code/README.md
+++ b/examples/user_code/README.md
@@ -13,14 +13,21 @@ You can quickly add your custom code into this folder so that quick prototypes c
 2. Add your custom *.cpp / *.hpp files here,. Hint: You might want to start by copying the [OpenPoseDemo](../openpose/openpose.cpp) example or any of the [examples/tutorial_api_cpp/](../tutorial_api_cpp/) examples. Then, you can simply modify their content.
 3. Add the name of your custom *.cpp / *.hpp files at the top of the [examples/user_code/CMakeLists.txt](./CMakeLists.txt) file.
 4. Re-compile OpenPose.
+### Ubuntu
 ```
-# Ubuntu/Mac
 cd build/
 make -j`nproc`
-# Windows
-# Close Visual Studio, re-run CMake, and re-compile the project in Visual Studio
 ```
-5. **Run step 4 every time that you make changes into your code**.
+### Mac
+```
+cd build/
+make -j`sysctl -n hw.logicalcpu`
+```
+### Windows
+Close Visual Studio, re-run CMake, and re-compile the project in Visual Studio
+
+
+### **Run step 4 every time that you make changes into your code**.
 
 
 

--- a/examples/user_code/README.md
+++ b/examples/user_code/README.md
@@ -13,21 +13,19 @@ You can quickly add your custom code into this folder so that quick prototypes c
 2. Add your custom *.cpp / *.hpp files here,. Hint: You might want to start by copying the [OpenPoseDemo](../openpose/openpose.cpp) example or any of the [examples/tutorial_api_cpp/](../tutorial_api_cpp/) examples. Then, you can simply modify their content.
 3. Add the name of your custom *.cpp / *.hpp files at the top of the [examples/user_code/CMakeLists.txt](./CMakeLists.txt) file.
 4. Re-compile OpenPose.
-### Ubuntu
+    1. Ubuntu
 ```
 cd build/
 make -j`nproc`
 ```
-### Mac
+    2. Mac
 ```
 cd build/
 make -j`sysctl -n hw.logicalcpu`
 ```
-### Windows
+    3. Windows
 Close Visual Studio, re-run CMake, and re-compile the project in Visual Studio
-
-
-### **Run step 4 every time that you make changes into your code**.
+5. **Run step 4 every time that you make changes into your code**.
 
 
 

--- a/examples/user_code/README.md
+++ b/examples/user_code/README.md
@@ -13,18 +13,19 @@ You can quickly add your custom code into this folder so that quick prototypes c
 2. Add your custom *.cpp / *.hpp files here,. Hint: You might want to start by copying the [OpenPoseDemo](../openpose/openpose.cpp) example or any of the [examples/tutorial_api_cpp/](../tutorial_api_cpp/) examples. Then, you can simply modify their content.
 3. Add the name of your custom *.cpp / *.hpp files at the top of the [examples/user_code/CMakeLists.txt](./CMakeLists.txt) file.
 4. Re-compile OpenPose.
-    1. Ubuntu
+  - Ubuntu
 ```
 cd build/
 make -j`nproc`
 ```
-    2. Mac
+
+  - Mac
 ```
 cd build/
 make -j`sysctl -n hw.logicalcpu`
 ```
-    3. Windows
-Close Visual Studio, re-run CMake, and re-compile the project in Visual Studio
+
+  - Windows: Close Visual Studio, re-run CMake, and re-compile the project in Visual Studio
 5. **Run step 4 every time that you make changes into your code**.
 
 

--- a/examples/user_code/README.md
+++ b/examples/user_code/README.md
@@ -12,20 +12,20 @@ You can quickly add your custom code into this folder so that quick prototypes c
 1. Install/compile OpenPose as usual.
 2. Add your custom *.cpp / *.hpp files here,. Hint: You might want to start by copying the [OpenPoseDemo](../openpose/openpose.cpp) example or any of the [examples/tutorial_api_cpp/](../tutorial_api_cpp/) examples. Then, you can simply modify their content.
 3. Add the name of your custom *.cpp / *.hpp files at the top of the [examples/user_code/CMakeLists.txt](./CMakeLists.txt) file.
-4. Re-compile OpenPose.
-  - Ubuntu
+4. Re-compile OpenPose. Depending on your OS, that means...
+  - Ubuntu:
 ```
 cd build/
 make -j`nproc`
 ```
 
-  - Mac
+  - Mac:
 ```
 cd build/
 make -j`sysctl -n hw.logicalcpu`
 ```
 
-  - Windows: Close Visual Studio, re-run CMake, and re-compile the project in Visual Studio
+  - Windows: Close Visual Studio, re-run CMake, and re-compile the project in Visual Studio.
 5. **Run step 4 every time that you make changes into your code**.
 
 

--- a/scripts/travis/run_make.sh
+++ b/scripts/travis/run_make.sh
@@ -8,8 +8,8 @@ source $BASEDIR/defaults.sh
 if [[ $WITH_CMAKE == true ]] ; then
   cd build
   if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make -j`nproc` ; fi
-  if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then make -j1 ; fi
+  if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then make -j`sysctl -n hw.logicalcpu` ; fi
 else
   if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make all -j`nproc` ; fi
-  if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then make all -j1 ; fi
+  if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then make all -j`sysctl -n hw.logicalcpu` ; fi
 fi


### PR DESCRIPTION
Upon further coding proceeds, found another unsquashed macos unavailable nproc.
Decreases travis build time too!
Fix last pr that uses the wrong command of phy cores instead of logical cores.
