### PR TITLE
sudo added at make install in Ubuntu. Also nproc.

### DIFF
--- a/doc/prerequisites.md
+++ b/doc/prerequisites.md
@@ -37,7 +37,7 @@ git submodule update --init --recursive --remote
         - Download the `Latest Release` of `CMake Unix/Linux Source` from the [CMake download website](https://cmake.org/download/), called `cmake-X.X.X.tar.gz`.
         - Unzip it and go inside that folder from the terminal.
         - Run `./configure --qt-gui`. Make sure no error occurred.
-        - Run `./bootstrap && make -j8 && make install -j8`. Make sure no error occurred.
+        - Run ``./bootstrap && make -j`nproc` && sudo make install -j`nproc` ``. Make sure no error occurred.
         - Assuming your CMake downloaded folder is in {CMAKE_FOLDER_PATH}, everytime these instructions mentions `cmake-gui`, you will have to replace that line by `{CMAKE_FOLDER_PATH}/bin/cmake-gui`.
 3. Nvidia GPU version prerequisites:
     1. **Note: OpenPose has been tested extensively with CUDA 8.0 (cuDNN 5.1) and CUDA 10.0 (cuDNN 7.5)**. We highly recommend using those versions to minimize potential installation issues. Other versions should also work, but we do not provide support about any CUDA/cuDNN installation/compilation issue, as well as problems relate dto their integration into OpenPose.


### PR DESCRIPTION
By using the default instructions, `make install` requires `sudo` to install the files into `/usr/local/bin/` thus the change or it will fail.
But to have the next instructions' path`{CMAKE_FOLDER_PATH}` to be applicable , either `bootstrap --prefix=<dir>` is needed instead of a one-liner `./boostrap &&...` or just to not using `make install` and using the built cmake under `<make dir>/bin` directly.
