### PR TITLE
Fix compilation for OpenCV 4

### DIFF
--- a/examples/tests/resizeTest.cpp
+++ b/examples/tests/resizeTest.cpp
@@ -79,7 +79,7 @@
         try
         {
             // logging_level
-            op::Matrix opImg = op::loadImage(FLAGS_image_path, CV_LOAD_IMAGE_GRAYSCALE);
+            op::Matrix opImg = op::loadImage(FLAGS_image_path, cv::IMREAD_GRAYSCALE);
             cv::Mat img = OP_OP2CVMAT(opImg);
             if(img.empty())
                 op::error("Could not open or find the image: " + FLAGS_image_path, __LINE__, __FUNCTION__, __FILE__);


### PR DESCRIPTION
Using OpenCV 4 and Ubuntu (18.04) on default settings, the compilation fail with :
```
examples/tests/resizeTest.cpp:82:64: error: ‘CV_LOAD_IMAGE_GRAYSCALE’ was not declared in this scope
             op::Matrix opImg = op::loadImage(FLAGS_image_path, CV_LOAD_IMAGE_GRAYSCALE);
```
This simple fix replace the legacy OpenCV C API by the C++ one.