### PR TITLE
Macro issue in `openCvMultiversionHeaders.hpp` that makes CV4+ not compatible

### DIFF
--- a/include/openpose_private/utilities/openCvMultiversionHeaders.hpp
+++ b/include/openpose_private/utilities/openCvMultiversionHeaders.hpp
@@ -39,17 +39,12 @@
     #define CV_WINDOW_NORMAL cv::WINDOW_NORMAL
     #define CV_WINDOW_OPENGL cv::WINDOW_OPENGL
     #define CV_WND_PROP_FULLSCREEN cv::WND_PROP_FULLSCREEN
-    // The following `CV_xxx` are enums required for alpha and beta versions, but not for rc version.
-    // In the versions that `CV_xxx` are used, the macros like `cvvConvertImage` are defined as well. 
-    // (see https://docs.opencv.org/4.0.0-alpha/da/d0a/group__imgcodecs__c.html for details)
     #include <opencv2/imgcodecs/imgcodecs.hpp>
-    #ifndef cvvConvertImage
-        #define CV_IMWRITE_JPEG_QUALITY cv::IMWRITE_JPEG_QUALITY
-        #define CV_IMWRITE_PNG_COMPRESSION cv::IMWRITE_PNG_COMPRESSION
-        #define CV_LOAD_IMAGE_ANYDEPTH cv::IMREAD_ANYDEPTH
-        #define CV_LOAD_IMAGE_COLOR cv::IMREAD_COLOR
-        #define CV_LOAD_IMAGE_GRAYSCALE cv::IMREAD_GRAYSCALE
-    #endif
+    #define CV_IMWRITE_JPEG_QUALITY cv::IMWRITE_JPEG_QUALITY
+    #define CV_IMWRITE_PNG_COMPRESSION cv::IMWRITE_PNG_COMPRESSION
+    #define CV_LOAD_IMAGE_ANYDEPTH cv::IMREAD_ANYDEPTH
+    #define CV_LOAD_IMAGE_COLOR cv::IMREAD_COLOR
+    #define CV_LOAD_IMAGE_GRAYSCALE cv::IMREAD_GRAYSCALE
 #endif
 
 #endif // OPENPOSE_PRIVATE_UTILITIES_OPENCV_MULTIVERSION_HEADERS_HPP

--- a/include/openpose_private/utilities/openCvMultiversionHeaders.hpp
+++ b/include/openpose_private/utilities/openCvMultiversionHeaders.hpp
@@ -39,21 +39,15 @@
     #define CV_WINDOW_NORMAL cv::WINDOW_NORMAL
     #define CV_WINDOW_OPENGL cv::WINDOW_OPENGL
     #define CV_WND_PROP_FULLSCREEN cv::WND_PROP_FULLSCREEN
-    // Required for alpha and beta versions, but not for rc version
+    // The following `CV_xxx` are enums required for alpha and beta versions, but not for rc version.
+    // In the versions that `CV_xxx` are used, the macros like `cvvConvertImage` are defined as well. 
+    // (see https://docs.opencv.org/4.0.0-alpha/da/d0a/group__imgcodecs__c.html for details)
     #include <opencv2/imgcodecs/imgcodecs.hpp>
-    #ifndef CV_IMWRITE_JPEG_QUALITY
+    #ifndef cvvConvertImage
         #define CV_IMWRITE_JPEG_QUALITY cv::IMWRITE_JPEG_QUALITY
-    #endif
-    #ifndef CV_IMWRITE_PNG_COMPRESSION
         #define CV_IMWRITE_PNG_COMPRESSION cv::IMWRITE_PNG_COMPRESSION
-    #endif
-    #ifndef CV_LOAD_IMAGE_ANYDEPTH
         #define CV_LOAD_IMAGE_ANYDEPTH cv::IMREAD_ANYDEPTH
-    #endif
-    #ifndef CV_LOAD_IMAGE_COLOR
         #define CV_LOAD_IMAGE_COLOR cv::IMREAD_COLOR
-    #endif
-    #ifndef CV_LOAD_IMAGE_GRAYSCALE
         #define CV_LOAD_IMAGE_GRAYSCALE cv::IMREAD_GRAYSCALE
     #endif
 #endif


### PR DESCRIPTION
In old versions, variables like `CV_IMWRITE_JPEG_QUALITY` are "enum"s not "define"s. Hence, "ifdef"s here are useless here and will make OpenCV4.0+(non-alpha/beta version) not able to compile. This can be fixed by detecting the macro `cvvConvertImage` which is along with CV_LOAD_xxx & CV_IMWRITE_xxx in old versions :)

[#1439](https://github.com/CMU-Perceptual-Computing-Lab/openpose/pull/1439) noticed the question as well, but his PR seems to be "OpenCV4-only". According to your original codes in `openCvMultiversionHeaders.hpp`, I fixed it by detecting the macro `cvvConvertImage`. And it compiled finally. Thx.