### PR TITLE
Don't try to tap homebrew/science

### DIFF
--- a/scripts/osx/install_deps.sh
+++ b/scripts/osx/install_deps.sh
@@ -1,7 +1,5 @@
 brew install openblas
 brew install -vd snappy leveldb gflags glog szip lmdb
-# need the homebrew science source for OpenCV and hdf5
-brew tap homebrew/science
 brew install hdf5 opencv
 # with Python pycaffe needs dependencies built from source
 #brew install --build-from-source --with-python -vd protobuf


### PR DESCRIPTION
homebrew/science is now deprecated, but opencv and hdf5 are now both in homebrew/core, so can be installed without tapping homebrew/science.