### PR TITLE
Improve Python API including enabled AsynchronousOut mode

### DIFF
--- a/examples/tutorial_api_python/01_body_from_image.py
+++ b/examples/tutorial_api_python/01_body_from_image.py
@@ -60,7 +60,7 @@ try:
     datum = op.Datum()
     imageToProcess = cv2.imread(args[0].image_path)
     datum.cvInputData = imageToProcess
-    opWrapper.emplaceAndPop([datum])
+    opWrapper.emplaceAndPop(op.VectorDatum([datum]))
 
     # Display Image
     print("Body keypoints: \n" + str(datum.poseKeypoints))

--- a/examples/tutorial_api_python/02_whole_body_from_image.py
+++ b/examples/tutorial_api_python/02_whole_body_from_image.py
@@ -62,7 +62,7 @@ try:
     datum = op.Datum()
     imageToProcess = cv2.imread(args[0].image_path)
     datum.cvInputData = imageToProcess
-    opWrapper.emplaceAndPop([datum])
+    opWrapper.emplaceAndPop(op.VectorDatum([datum]))
 
     # Display Image
     print("Body keypoints: \n" + str(datum.poseKeypoints))

--- a/examples/tutorial_api_python/04_keypoints_from_images.py
+++ b/examples/tutorial_api_python/04_keypoints_from_images.py
@@ -67,7 +67,7 @@ try:
         datum = op.Datum()
         imageToProcess = cv2.imread(imagePath)
         datum.cvInputData = imageToProcess
-        opWrapper.emplaceAndPop([datum])
+        opWrapper.emplaceAndPop(op.VectorDatum([datum]))
 
         print("Body keypoints: \n" + str(datum.poseKeypoints))
 

--- a/examples/tutorial_api_python/05_keypoints_from_images_multi_gpu.py
+++ b/examples/tutorial_api_python/05_keypoints_from_images_multi_gpu.py
@@ -71,7 +71,6 @@ try:
     for imageBaseId in range(0, len(imagePaths), numberGPUs):
 
         # Create datums
-        datums = []
         images = []
 
         # Read and push images into OpenPose wrapper
@@ -84,8 +83,7 @@ try:
                 datum = op.Datum()
                 images.append(cv2.imread(imagePath))
                 datum.cvInputData = images[-1]
-                datums.append(datum)
-                opWrapper.waitAndEmplace([datums[-1]])
+                opWrapper.waitAndEmplace(op.VectorDatum([datum]))
 
         # Retrieve processed results from OpenPose wrapper
         for gpuId in range(0, numberGPUs):
@@ -93,8 +91,9 @@ try:
             imageId = imageBaseId+gpuId
             if imageId < len(imagePaths):
 
-                datum = datums[gpuId]
-                opWrapper.waitAndPop([datum])
+                datums = op.VectorDatum()
+                opWrapper.waitAndPop(datums)
+                datum = datums[0]
 
                 print("Body keypoints: \n" + str(datum.poseKeypoints))
 

--- a/examples/tutorial_api_python/06_face_from_image.py
+++ b/examples/tutorial_api_python/06_face_from_image.py
@@ -74,7 +74,7 @@ try:
     datum.faceRectangles = faceRectangles
 
     # Process and display image
-    opWrapper.emplaceAndPop([datum])
+    opWrapper.emplaceAndPop(op.VectorDatum([datum]))
     print("Face keypoints: \n" + str(datum.faceKeypoints))
     cv2.imshow("OpenPose 1.6.0 - Tutorial Python API", datum.cvOutputData)
     cv2.waitKey(0)

--- a/examples/tutorial_api_python/08_heatmaps_from_image.py
+++ b/examples/tutorial_api_python/08_heatmaps_from_image.py
@@ -64,7 +64,7 @@ try:
     datum = op.Datum()
     imageToProcess = cv2.imread(args[0].image_path)
     datum.cvInputData = imageToProcess
-    opWrapper.emplaceAndPop([datum])
+    opWrapper.emplaceAndPop(op.VectorDatum([datum]))
 
     # Process outputs
     outputImageF = (datum.inputNetData[0].copy())[0,:,:,:] + 0.5

--- a/examples/tutorial_api_python/09_keypoints_from_heatmaps.py
+++ b/examples/tutorial_api_python/09_keypoints_from_heatmaps.py
@@ -77,7 +77,7 @@ try:
     datum = op.Datum()
     datum.cvInputData = imageToProcess
     datum.poseNetOutput = poseHeatMaps
-    opWrapper.emplaceAndPop([datum])
+    opWrapper.emplaceAndPop(op.VectorDatum([datum]))
 
     # Display Image
     print("Body keypoints: \n" + str(datum.poseKeypoints))

--- a/examples/tutorial_api_python/12_asynchronous_custom_output.py
+++ b/examples/tutorial_api_python/12_asynchronous_custom_output.py
@@ -5,7 +5,22 @@ import cv2
 import os
 from sys import platform
 import argparse
-import time
+
+
+def display(datums):
+    datum = datums[0]
+    cv2.imshow("OpenPose 1.6.0 - Tutorial Python API", datum.cvOutputData)
+    key = cv2.waitKey(1)
+    return (key == 27)
+
+
+def printKeypoints(datums):
+    datum = datums[0]
+    print("Body keypoints: \n" + str(datum.poseKeypoints))
+    print("Face keypoints: \n" + str(datum.faceKeypoints))
+    print("Left hand keypoints: \n" + str(datum.handKeypoints[0]))
+    print("Right hand keypoints: \n" + str(datum.handKeypoints[1]))
+
 
 try:
     # Import Openpose (Windows/Ubuntu/OSX)
@@ -29,15 +44,12 @@ try:
 
     # Flags
     parser = argparse.ArgumentParser()
-    parser.add_argument("--image_path", default="../../../examples/media/COCO_val2014_000000000241.jpg", help="Process an image. Read all standard formats (jpg, png, bmp, etc.).")
+    parser.add_argument("--no-display", action="store_true", help="Disable display.")
     args = parser.parse_known_args()
 
     # Custom Params (refer to include/openpose/flags.hpp for more parameters)
     params = dict()
     params["model_folder"] = "../../../models/"
-    params["hand"] = True
-    params["hand_detector"] = 2
-    params["body"] = 0
 
     # Add others in path?
     for i in range(0, len(args[1])):
@@ -60,37 +72,18 @@ try:
     opWrapper.configure(params)
     opWrapper.start()
 
-    # Read image and face rectangle locations
-    imageToProcess = cv2.imread(args[0].image_path)
-    handRectangles = [
-        # Left/Right hands person 0
-        [
-        op.Rectangle(320.035889, 377.675049, 69.300949, 69.300949),
-        op.Rectangle(0., 0., 0., 0.),
-        ],
-        # Left/Right hands person 1
-        [
-        op.Rectangle(80.155792, 407.673492, 80.812706, 80.812706),
-        op.Rectangle(46.449715, 404.559753, 98.898178, 98.898178),
-        ],
-        # Left/Right hands person 2
-        [
-        op.Rectangle(185.692673, 303.112244, 157.587555, 157.587555),
-        op.Rectangle(88.984360, 268.866547, 117.818230, 117.818230),
-        ]
-    ]
-
-    # Create new datum
-    datum = op.Datum()
-    datum.cvInputData = imageToProcess
-    datum.handRectangles = handRectangles
-
-    # Process and display image
-    opWrapper.emplaceAndPop(op.VectorDatum([datum]))
-    print("Left hand keypoints: \n" + str(datum.handKeypoints[0]))
-    print("Right hand keypoints: \n" + str(datum.handKeypoints[1]))
-    cv2.imshow("OpenPose 1.6.0 - Tutorial Python API", datum.cvOutputData)
-    cv2.waitKey(0)
+    # Main loop
+    userWantsToExit = False
+    while not userWantsToExit:
+        # Pop frame
+        datumProcessed = op.VectorDatum()
+        if opWrapper.waitAndPop(datumProcessed):
+            if not args[0].no_display:
+                # Display image
+                userWantsToExit = display(datumProcessed)
+            printKeypoints(datumProcessed)
+        else:
+            break
 except Exception as e:
     print(e)
     sys.exit(-1)

--- a/examples/tutorial_api_python/12_asynchronous_custom_output.py
+++ b/examples/tutorial_api_python/12_asynchronous_custom_output.py
@@ -68,7 +68,7 @@ try:
     # oppython = op.OpenposePython()
 
     # Starting OpenPose
-    opWrapper = op.WrapperPython()
+    opWrapper = op.WrapperPython(op.ThreadManagerMode.AsynchronousOut)
     opWrapper.configure(params)
     opWrapper.start()
 

--- a/examples/tutorial_api_python/openpose_python.py
+++ b/examples/tutorial_api_python/openpose_python.py
@@ -52,7 +52,7 @@ try:
     # oppython = op.OpenposePython()
 
     # Starting OpenPose
-    opWrapper = op.WrapperPython(3)
+    opWrapper = op.WrapperPython(op.ThreadManagerMode.Synchronous)
     opWrapper.configure(params)
     opWrapper.execute()
 except Exception as e:

--- a/python/openpose/openpose_python.cpp
+++ b/python/openpose/openpose_python.cpp
@@ -446,6 +446,9 @@ template <> struct type_caster<op::Array<float>> {
         static handle cast(const op::Array<float> &m, return_value_policy, handle defval)
         {
             UNUSED(defval);
+            if (m.getSize().size() == 0) {
+                return none();
+            }
             std::string format = format_descriptor<float>::format();
             return array(buffer_info(
                 m.getPseudoConstPtr(),/* Pointer to buffer */

--- a/python/openpose/openpose_python.cpp
+++ b/python/openpose/openpose_python.cpp
@@ -463,6 +463,42 @@ template <> struct type_caster<op::Array<float>> {
     };
 }} // namespace pybind11::detail
 
+// Numpy - op::Array<long long> interop
+namespace pybind11 { namespace detail {
+
+template <> struct type_caster<op::Array<long long>> {
+    public:
+
+        PYBIND11_TYPE_CASTER(op::Array<long long>, _("numpy.ndarray"));
+
+        // Cast numpy to op::Array<long long>
+        bool load(handle src, bool imp)
+        {
+            op::error("op::Array<long long> is read only now", __LINE__, __FUNCTION__, __FILE__);
+            return false;
+        }
+
+        // Cast op::Array<long long> to numpy
+        static handle cast(const op::Array<long long> &m, return_value_policy, handle defval)
+        {
+            UNUSED(defval);
+            if (m.getSize().size() == 0) {
+                return none();
+            }
+            std::string format = format_descriptor<long long>::format();
+            return array(buffer_info(
+                m.getPseudoConstPtr(),/* Pointer to buffer */
+                sizeof(long long),    /* Size of one scalar */
+                format,               /* Python struct-style format descriptor */
+                m.getSize().size(),   /* Number of dimensions */
+                m.getSize(),          /* Buffer dimensions */
+                m.getStride()         /* Strides (in bytes) for each index */
+                )).release();
+        }
+
+    };
+}} // namespace pybind11::detail
+
 // Numpy - op::Matrix interop
 namespace pybind11 { namespace detail {
 

--- a/python/openpose/openpose_python.cpp
+++ b/python/openpose/openpose_python.cpp
@@ -168,6 +168,18 @@ namespace op
                     op::String(FLAGS_write_video_adam), op::String(FLAGS_write_bvh), op::String(FLAGS_udp_host),
                     op::String(FLAGS_udp_port)};
                 opWrapper->configure(wrapperStructOutput);
+                // Producer (use default to disable any input)
+                const auto cameraSize = flagsToPoint(op::String(FLAGS_camera_resolution), "-1x-1");
+                ProducerType producerType;
+                op::String producerString;
+                std::tie(producerType, producerString) = flagsToProducer(
+                    op::String(FLAGS_image_dir), op::String(FLAGS_video), op::String(FLAGS_ip_camera), FLAGS_camera,
+                    FLAGS_flir_camera, FLAGS_flir_camera_index);
+                const WrapperStructInput wrapperStructInput{
+                    producerType, producerString, FLAGS_frame_first, FLAGS_frame_step, FLAGS_frame_last,
+                    FLAGS_process_real_time, FLAGS_frame_flip, FLAGS_frame_rotate, FLAGS_frames_repeat,
+                    cameraSize, op::String(FLAGS_camera_parameter_path), FLAGS_frame_undistort, FLAGS_3d_views};
+                opWrapper->configure(wrapperStructInput);
                 // No GUI. Equivalent to: opWrapper.configure(WrapperStructGui{});
                 // Set to single-thread (for sequential processing and/or debugging and/or reducing latency)
                 if (FLAGS_disable_multi_thread)
@@ -207,18 +219,6 @@ namespace op
         {
             try
             {
-                const auto cameraSize = flagsToPoint(op::String(FLAGS_camera_resolution), "-1x-1");
-                ProducerType producerType;
-                op::String producerString;
-                std::tie(producerType, producerString) = flagsToProducer(
-                    op::String(FLAGS_image_dir), op::String(FLAGS_video), op::String(FLAGS_ip_camera), FLAGS_camera,
-                    FLAGS_flir_camera, FLAGS_flir_camera_index);
-                // Producer (use default to disable any input)
-                const WrapperStructInput wrapperStructInput{
-                    producerType, producerString, FLAGS_frame_first, FLAGS_frame_step, FLAGS_frame_last,
-                    FLAGS_process_real_time, FLAGS_frame_flip, FLAGS_frame_rotate, FLAGS_frames_repeat,
-                    cameraSize, op::String(FLAGS_camera_parameter_path), FLAGS_frame_undistort, FLAGS_3d_views};
-                opWrapper->configure(wrapperStructInput);
                 // GUI (comment or use default argument to disable any visual output)
                 const WrapperStructGui wrapperStructGui{
                     flagsToDisplayMode(FLAGS_display, FLAGS_3d), !FLAGS_no_gui_verbose, FLAGS_fullscreen};

--- a/python/openpose/openpose_python.cpp
+++ b/python/openpose/openpose_python.cpp
@@ -87,7 +87,7 @@ namespace op
             opLog("Starting OpenPose Python Wrapper...", Priority::High);
 
             // Construct opWrapper
-            opWrapper = std::unique_ptr<Wrapper>(new Wrapper(static_cast<ThreadManagerMode>(mode)));
+            opWrapper = std::unique_ptr<Wrapper>(new Wrapper(mode));
         }
 
         void configure(py::dict params = py::dict())

--- a/python/openpose/openpose_python.cpp
+++ b/python/openpose/openpose_python.cpp
@@ -249,9 +249,12 @@ namespace op
         {
             try
             {
-                std::shared_ptr<std::vector<std::shared_ptr<Datum>>> datumsPtr(&l);
+                std::shared_ptr<std::vector<std::shared_ptr<Datum>>> datumsPtr(
+                    &l,
+                    [](std::vector<std::shared_ptr<Datum>>*){}
+                );
                 auto got = opWrapper->emplaceAndPop(datumsPtr);
-                if (got) {
+                if (got && datumsPtr.get() != &l) {
                     l.swap(*datumsPtr);
                 }
                 return got;

--- a/python/openpose/openpose_python.cpp
+++ b/python/openpose/openpose_python.cpp
@@ -82,7 +82,7 @@ namespace op
     public:
         std::unique_ptr<Wrapper> opWrapper;
 
-        WrapperPython(int mode = 0)
+        WrapperPython(ThreadManagerMode mode = ThreadManagerMode::Asynchronous)
         {
             opLog("Starting OpenPose Python Wrapper...", Priority::High);
 
@@ -324,7 +324,7 @@ namespace op
         // OpenposePython
         py::class_<WrapperPython>(m, "WrapperPython")
             .def(py::init<>())
-            .def(py::init<int>())
+            .def(py::init<ThreadManagerMode>())
             .def("configure", &WrapperPython::configure)
             .def("start", &WrapperPython::start)
             .def("stop", &WrapperPython::stop)
@@ -332,6 +332,14 @@ namespace op
             .def("emplaceAndPop", &WrapperPython::emplaceAndPop)
             .def("waitAndEmplace", &WrapperPython::waitAndEmplace)
             .def("waitAndPop", &WrapperPython::waitAndPop)
+            ;
+
+        // ThreadManagerMode
+        py::enum_<ThreadManagerMode>(m, "ThreadManagerMode")
+            .value("Asynchronous", ThreadManagerMode::Asynchronous)
+            .value("AsynchronousIn", ThreadManagerMode::AsynchronousIn)
+            .value("AsynchronousOut", ThreadManagerMode::AsynchronousOut)
+            .value("Synchronous", ThreadManagerMode::Synchronous)
             ;
 
         // Datum Object


### PR DESCRIPTION
Currently AsynchronousOut mode won't work with the Python API since it is not possible to get ahold of a Datum created inside OpenPose from the Python side. The reason for this is at the moment, lists are copied when going over the Python => C++ boundary. See https://pybind11.readthedocs.io/en/stable/advanced/cast/stl.html#making-opaque-types . To get the semantics of passing a mutable reference, we can wrap an STL type.

Unfortunately this is not quite sufficient. We need to pass a shared_pointer<vector<shared_pointer<datum>>> to `openpose::Wrapper`. The outer shared pointer is eventually pointed somewhere else in `queue.hpp`:

https://github.com/CMU-Perceptual-Computing-Lab/openpose/blob/3915b922eb345de9d788cb46541d42641aa014c4/include/openpose/thread/queue.hpp#L73

So we just swap that vector with ours, which should avoid copying the datum I think. I'm a bit confused about why there are so many levels of nesting though. A more idiomatic approach would be to just return a value in Python, but since the Python/C++ APIs are currently very similar, I thought I'd keep it this way and just adjust it to work in this case also. 

This PR also contains the following related changes:
 * Update Python tutorial for adjusted API and port C++ AsynchronousOut example to Python
 * Add ThreadManagerMode enum to Python interface

And a couple of unrelated bug fixes to the Python API:
 * Add `type_caster<op::Array<long long>>` so datum.poseIds can be accessed from Python
 * Cast empty Arrays on Datum to None in Python rather than numpy scalars of trash data.