### PR TITLE
Added OpenSSL for fresh Ubuntu 18.04 installation

### DIFF
--- a/doc/prerequisites.md
+++ b/doc/prerequisites.md
@@ -34,7 +34,7 @@ git submodule update --init --recursive --remote
     - Ubuntu 14 or 16: run the command `sudo apt-get install cmake-qt-gui`. Note: If you prefer to use CMake through the command line, see [doc/installation.md#CMake Command Line Configuration (Ubuntu Only)](./installation.md#cmake-command-line-configuration-ubuntu-only).
     - Ubuntu 18: **Download and compile CMake-gui from source**. The default CMake-gui version (3.10) installed via `sudo apt-get install cmake-qt-gui` provokes some compiling errors. Required CMake version >= 3.12.
         - Uninstall your current Cmake-gui version by running `sudo apt purge cmake-qt-gui`.
-        - Install OpenSSL for building CMake by `sudo apt install libssl-dev`.
+        - Install OpenSSL for building CMake by running `sudo apt install libssl-dev`.
         - Run `sudo apt-get install qtbase5-dev`.
         - Download the `Latest Release` of `CMake Unix/Linux Source` from the [CMake download website](https://cmake.org/download/), called `cmake-X.X.X.tar.gz`.
         - Unzip it and go inside that folder from the terminal.

--- a/doc/prerequisites.md
+++ b/doc/prerequisites.md
@@ -34,7 +34,7 @@ git submodule update --init --recursive --remote
     - Ubuntu 14 or 16: run the command `sudo apt-get install cmake-qt-gui`. Note: If you prefer to use CMake through the command line, see [doc/installation.md#CMake Command Line Configuration (Ubuntu Only)](./installation.md#cmake-command-line-configuration-ubuntu-only).
     - Ubuntu 18: **Download and compile CMake-gui from source**. The default CMake-gui version (3.10) installed via `sudo apt-get install cmake-qt-gui` provokes some compiling errors. Required CMake version >= 3.12.
         - Uninstall your current Cmake-gui version by running `sudo apt purge cmake-qt-gui`.
-        - If your system is a clean install, you'll need to install OpenSSL for building cmake by `sudo apt install libssl-dev`.
+        - Install OpenSSL for building CMake by `sudo apt install libssl-dev`.
         - Run `sudo apt-get install qtbase5-dev`.
         - Download the `Latest Release` of `CMake Unix/Linux Source` from the [CMake download website](https://cmake.org/download/), called `cmake-X.X.X.tar.gz`.
         - Unzip it and go inside that folder from the terminal.

--- a/doc/prerequisites.md
+++ b/doc/prerequisites.md
@@ -34,6 +34,7 @@ git submodule update --init --recursive --remote
     - Ubuntu 14 or 16: run the command `sudo apt-get install cmake-qt-gui`. Note: If you prefer to use CMake through the command line, see [doc/installation.md#CMake Command Line Configuration (Ubuntu Only)](./installation.md#cmake-command-line-configuration-ubuntu-only).
     - Ubuntu 18: **Download and compile CMake-gui from source**. The default CMake-gui version (3.10) installed via `sudo apt-get install cmake-qt-gui` provokes some compiling errors. Required CMake version >= 3.12.
         - Uninstall your current Cmake-gui version by running `sudo apt purge cmake-qt-gui`.
+        - If your system is a clean install, you'll need to install OpenSSL for building cmake by `sudo apt install libssl-dev`.
         - Run `sudo apt-get install qtbase5-dev`.
         - Download the `Latest Release` of `CMake Unix/Linux Source` from the [CMake download website](https://cmake.org/download/), called `cmake-X.X.X.tar.gz`.
         - Unzip it and go inside that folder from the terminal.


### PR DESCRIPTION
OpenSSL does not come preinstalled in a fresh Ubuntu 18.04 install, so we'll need to get `libssl-dev` for it.