### PR TITLE
Update script for downloading CUDA 11 for Ubuntu 20 or later versions

### DIFF
--- a/scripts/ubuntu/install_cuda.sh
+++ b/scripts/ubuntu/install_cuda.sh
@@ -25,5 +25,14 @@ elif [[ $ubuntu_version == *"18."* ]]; then
   sudo apt-key add /var/cuda-repo-10-2-local-10.2.89-440.33.01/7fa2af80.pub
   sudo apt-get update
   sudo apt-get -y install cuda
+# Install CUDA 11.0
+elif [[ $ubuntu_version == *"20."* ]]; then
+  wget -c "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin"
+  sudo mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600
+  wget "https://developer.download.nvidia.com/compute/cuda/11.0.3/local_installers/cuda-repo-ubuntu2004-11-0-local_11.0.3-450.51.06-1_amd64.deb"
+  sudo dpkg -i cuda-repo-ubuntu2004-11-0-local_11.0.3-450.51.06-1_amd64.deb
+  sudo apt-key add /var/cuda-repo-ubuntu2004-11-0-local/7fa2af80.pub
+  sudo apt-get update
+  sudo apt-get -y install cuda
 fi
 # sudo apt-get install cuda


### PR DESCRIPTION
CUDA installation has failed for Ubuntu 20.04 and unfortunately has to be continued with manual steps. So, the script is updated for CUDA 11 for Ubuntu 20.x versions to download automatically. 