### PR TITLE
Update install scripts for Ubuntu 20 and fix make error on cuDNN 8.0 for CUDA 11

### DIFF
--- a/cmake/Cuda.cmake
+++ b/cmake/Cuda.cmake
@@ -229,12 +229,16 @@ function(detect_cuDNN)
   find_library(CUDNN_LIBRARY NAMES ${CUDNN_LIB_NAME}
    PATHS ${CUDNN_ROOT} $ENV{CUDNN_ROOT} ${CUDNN_INCLUDE} ${__libpath_hist} ${__libpath_hist}/../lib
    DOC "Path to cuDNN library.")
-  
+
   if (CUDNN_INCLUDE AND CUDNN_LIBRARY)
     set(HAVE_CUDNN  TRUE PARENT_SCOPE)
     set(CUDNN_FOUND TRUE PARENT_SCOPE)
 
-    file(READ ${CUDNN_INCLUDE}/cudnn.h CUDNN_VERSION_FILE_CONTENTS)
+    if(EXISTS "${CUDNN_INCLUDE}/cudnn_version.h")
+        file(READ ${CUDNN_INCLUDE}/cudnn_version.h CUDNN_VERSION_FILE_CONTENTS)
+    else()
+        file(READ ${CUDNN_INCLUDE}/cudnn.h CUDNN_VERSION_FILE_CONTENTS)
+    endif()
 
     # cuDNN v3 and beyond
     string(REGEX MATCH "define CUDNN_MAJOR * +([0-9]+)"

--- a/cmake/Modules/FindCuDNN.cmake
+++ b/cmake/Modules/FindCuDNN.cmake
@@ -14,7 +14,11 @@ if(CUDNN_INCLUDE AND CUDNN_LIBRARY)
     set(HAVE_CUDNN  TRUE)
     set(CUDNN_FOUND TRUE)
 
-    file(READ ${CUDNN_INCLUDE}/cudnn.h CUDNN_VERSION_FILE_CONTENTS)
+    if(EXISTS "${CUDNN_INCLUDE}/cudnn_version.h")
+        file(READ ${CUDNN_INCLUDE}/cudnn_version.h CUDNN_VERSION_FILE_CONTENTS)
+    else()
+        file(READ ${CUDNN_INCLUDE}/cudnn.h CUDNN_VERSION_FILE_CONTENTS)
+    endif()
 
     # cuDNN v3 and beyond
     string(REGEX MATCH "define CUDNN_MAJOR * +([0-9]+)"

--- a/scripts/ubuntu/install_cudnn.sh
+++ b/scripts/ubuntu/install_cudnn.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 
-echo "NOTE: This script assumes Ubuntu 16 or 14 and Nvidia Graphics card up to 10XX. Otherwise, install it by yourself or it will fail."
+ubuntu_version="$(lsb_release -r)"
+
+if [[ $ubuntu_version != *"14."* ]] && [[ $ubuntu_version != *"16."* ]]; then
+  # Ubuntu 14,16 display warning and exit
+  echo "NOTE: This script assumes Ubuntu 16 or 14 and Nvidia Graphics card up to 10XX. Otherwise, install it by yourself or it will fail."
+  echo "  See https://developer.nvidia.com/cudnn"
+  exit
+fi
 
 # Install cuDNN 5.1
 CUDNN_URL="http://developer.download.nvidia.com/compute/redist/cudnn/v5.1/cudnn-8.0-linux-x64-v5.1.tgz"

--- a/scripts/ubuntu/install_deps.sh
+++ b/scripts/ubuntu/install_deps.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 ### INSTALL PREREQUISITES
+ubuntu_version="$(lsb_release -r)"
 
 # Basic
 sudo apt-get --assume-yes update
@@ -10,10 +11,12 @@ sudo apt-get --assume-yes install libatlas-base-dev libprotobuf-dev libleveldb-d
 sudo apt-get --assume-yes install --no-install-recommends libboost-all-dev
 # Remaining dependencies, 14.04
 sudo apt-get --assume-yes install libgflags-dev libgoogle-glog-dev liblmdb-dev
-# Python2 libs
-sudo apt-get --assume-yes install python-setuptools python-dev build-essential
-sudo easy_install pip
-sudo -H pip install --upgrade numpy protobuf opencv-python
+if [[ $ubuntu_version != *"20."* ]]; then
+  # Python2 libs - Skip due to Ubuntu 20 dropped Python2
+  sudo apt-get --assume-yes install python-setuptools python-dev build-essential
+  sudo easy_install pip
+  sudo -H pip install --upgrade numpy protobuf opencv-python
+fi
 # Python3 libs
 sudo apt-get --assume-yes install python3-setuptools python3-dev build-essential
 sudo apt-get --assume-yes install python3-pip


### PR DESCRIPTION
After @cngzhnp updated the install script for CUDA (big shoutout!!!) this PR adjusts the other scripts to make `install_deps_and_cuda.sh` work like expected:
- `install_cudnn.sh` throws an error on Ubuntu > 16
- `install_deps.sh` skips installation of Python2 packages due to dropped Python2 support in Ubuntu 20 <br>
- Further fixed error on `make`: Reading version of cuDNN failed on "cuDNN v8.0.4 (September 28th, 2020), for CUDA 11.0" due to version information were extracted to file `cudnn_version.h`. 

So all errors with message ``Found cuDNN: ver. ???`` with cuDNN 8.x are probably related to this
```
Found cuDNN: ver. ??? found (include: /usr/include, library: /usr/lib/x86_64-linux-gnu/)
```

-----

All tested on Ubuntu 20.04.1 LTS with CUDA Version: 11.0 (from `install_cuda.sh`)