### PR TITLE
Remove compute capability 3.0 from default list (dropped from CUDA 11.1)

### DIFF
--- a/cmake/Cuda.cmake
+++ b/cmake/Cuda.cmake
@@ -33,11 +33,11 @@ set(VOLTA "70") # set(VOLTA "70 71 72") # This crashes with CUDA 10
 # Turing (CUDA >= 10)
 set(TURING "75")
 if (UNIX AND NOT APPLE)
-  set(Caffe_known_gpu_archs "${KEPLER} ${MAXWELL} ${PASCAL} ${VOLTA} ${TURING}")
+  set(Caffe_known_gpu_archs "35 37 ${MAXWELL} ${PASCAL} ${VOLTA} ${TURING}")
   # set(Caffe_known_gpu_archs "${FERMI} ${KEPLER} ${MAXWELL} ${PASCAL} ${VOLTA} ${TURING}")
   # set(Caffe_known_gpu_archs "20 21(20) 30 35 50 52 60 61")
 elseif (WIN32)
-  set(Caffe_known_gpu_archs "${KEPLER} ${MAXWELL} ${PASCAL} ${VOLTA} ${TURING}")
+  set(Caffe_known_gpu_archs "35 37 ${MAXWELL} ${PASCAL} ${VOLTA} ${TURING}")
 endif ()
 
 


### PR DESCRIPTION
CUDA 11.1 has dropped support for compute capability 3.0 (and deprecated the other Kepler computes 3.5 and 3.7 --- but they still work for now). The simplest thing to prevent people having problems is probably to remove it from the default arch list e.g. at least one person has encountered it https://github.com/CMU-Perceptual-Computing-Lab/openpose/issues/1695#issuecomment-712739691