### PR TITLE
Fix cudnn version not found error

### DIFF
--- a/cmake/Cuda.cmake
+++ b/cmake/Cuda.cmake
@@ -235,6 +235,7 @@ function(detect_cuDNN)
     set(CUDNN_FOUND TRUE PARENT_SCOPE)
 
     file(READ ${CUDNN_INCLUDE}/cudnn.h CUDNN_VERSION_FILE_CONTENTS)
+    file(READ ${CUDNN_INCLUDE}/cudnn_version.h CUDNN_VERSION_FILE_CONTENTS2)
 
     # cuDNN v3 and beyond
     string(REGEX MATCH "define CUDNN_MAJOR * +([0-9]+)"
@@ -251,9 +252,25 @@ function(detect_cuDNN)
            CUDNN_VERSION_PATCH "${CUDNN_VERSION_PATCH}")
 
     if (NOT CUDNN_VERSION_MAJOR)
-      set(CUDNN_VERSION "???")
-    else ()
-      set(CUDNN_VERSION "${CUDNN_VERSION_MAJOR}.${CUDNN_VERSION_MINOR}.${CUDNN_VERSION_PATCH}")
+		# cuDNN v3 and beyond
+    	string(REGEX MATCH "define CUDNN_MAJOR * +([0-9]+)"
+    	       CUDNN_VERSION_MAJOR "${CUDNN_VERSION_FILE_CONTENTS2}")
+    	string(REGEX REPLACE "define CUDNN_MAJOR * +([0-9]+)" "\\1"
+    	       CUDNN_VERSION_MAJOR "${CUDNN_VERSION_MAJOR}")
+    	string(REGEX MATCH "define CUDNN_MINOR * +([0-9]+)"
+    	       CUDNN_VERSION_MINOR "${CUDNN_VERSION_FILE_CONTENTS2}")
+    	string(REGEX REPLACE "define CUDNN_MINOR * +([0-9]+)" "\\1"
+    	       CUDNN_VERSION_MINOR "${CUDNN_VERSION_MINOR}")
+    	string(REGEX MATCH "define CUDNN_PATCHLEVEL * +([0-9]+)"
+    	       CUDNN_VERSION_PATCH "${CUDNN_VERSION_FILE_CONTENTS2}")
+    	string(REGEX REPLACE "define CUDNN_PATCHLEVEL * +([0-9]+)" "\\1"
+    	       CUDNN_VERSION_PATCH "${CUDNN_VERSION_PATCH}")
+
+    	if (NOT CUDNN_VERSION_MAJOR)
+      		set(CUDNN_VERSION "???")
+	    else ()
+   		   set(CUDNN_VERSION "${CUDNN_VERSION_MAJOR}.${CUDNN_VERSION_MINOR}.${CUDNN_VERSION_PATCH}")
+		endif()
     endif ()
 
     message(STATUS "Found cuDNN: ver. ${CUDNN_VERSION} found (include: ${CUDNN_INCLUDE}, library: ${CUDNN_LIBRARY})")

--- a/cmake/Modules/FindCuDNN.cmake
+++ b/cmake/Modules/FindCuDNN.cmake
@@ -2,8 +2,12 @@ set(CUDNN_ROOT "" CACHE PATH "CUDNN root folder")
 set(CUDNN_LIB_NAME "libcudnn.so")
 
 find_path(CUDNN_INCLUDE cudnn.h
-    PATHS ${CUDNN_ROOT} $ENV{CUDNN_ROOT} ${CUDA_TOOLKIT_INCLUDE}
+    PATHS ${CUDNN_ROOT} $ENV{CUDNN_ROOT} ${CUDA_TOOLKIT_INCLUDE} /usr/local/cuda/include
     DOC "Path to cuDNN include directory." )
+
+find_library(CUDNN_LIBRARY NAMES ${CUDNN_LIB_NAME}
+    PATHS ${CUDNN_ROOT} $ENV{CUDNN_ROOT} ${CUDNN_INCLUDE} ${__libpath_hist} ${__libpath_hist}/../lib /usr/local/cuda/lib64
+    DOC "Path to cuDNN library.")
 
 get_filename_component(__libpath_hist ${CUDA_CUDART_LIBRARY} PATH)
 find_library(CUDNN_LIBRARY NAMES ${CUDNN_LIB_NAME}
@@ -15,6 +19,7 @@ if(CUDNN_INCLUDE AND CUDNN_LIBRARY)
     set(CUDNN_FOUND TRUE)
 
     file(READ ${CUDNN_INCLUDE}/cudnn.h CUDNN_VERSION_FILE_CONTENTS)
+    file(READ ${CUDNN_INCLUDE}/cudnn_version.h CUDNN_VERSION_FILE_CONTENTS2)
 
     # cuDNN v3 and beyond
     string(REGEX MATCH "define CUDNN_MAJOR * +([0-9]+)"
@@ -31,9 +36,25 @@ if(CUDNN_INCLUDE AND CUDNN_LIBRARY)
            CUDNN_VERSION_PATCH "${CUDNN_VERSION_PATCH}")
 
     if (NOT CUDNN_VERSION_MAJOR)
-      set(CUDNN_VERSION "???")
-    else ()
-      set(CUDNN_VERSION "${CUDNN_VERSION_MAJOR}.${CUDNN_VERSION_MINOR}.${CUDNN_VERSION_PATCH}")
+		# cuDNN v3 and beyond
+    	string(REGEX MATCH "define CUDNN_MAJOR * +([0-9]+)"
+    	       CUDNN_VERSION_MAJOR "${CUDNN_VERSION_FILE_CONTENTS2}")
+    	string(REGEX REPLACE "define CUDNN_MAJOR * +([0-9]+)" "\\1"
+    	       CUDNN_VERSION_MAJOR "${CUDNN_VERSION_MAJOR}")
+    	string(REGEX MATCH "define CUDNN_MINOR * +([0-9]+)"
+    	       CUDNN_VERSION_MINOR "${CUDNN_VERSION_FILE_CONTENTS2}")
+    	string(REGEX REPLACE "define CUDNN_MINOR * +([0-9]+)" "\\1"
+    	       CUDNN_VERSION_MINOR "${CUDNN_VERSION_MINOR}")
+    	string(REGEX MATCH "define CUDNN_PATCHLEVEL * +([0-9]+)"
+    	       CUDNN_VERSION_PATCH "${CUDNN_VERSION_FILE_CONTENTS2}")
+    	string(REGEX REPLACE "define CUDNN_PATCHLEVEL * +([0-9]+)" "\\1"
+    	       CUDNN_VERSION_PATCH "${CUDNN_VERSION_PATCH}")
+
+    	if (NOT CUDNN_VERSION_MAJOR)
+      		set(CUDNN_VERSION "???")
+		else()
+      		set(CUDNN_VERSION "${CUDNN_VERSION_MAJOR}.${CUDNN_VERSION_MINOR}.${CUDNN_VERSION_PATCH}")
+		endif()
     endif()
 
     message(STATUS "Found cuDNN: ver. ${CUDNN_VERSION} found (include: ${CUDNN_INCLUDE}, library: ${CUDNN_LIBRARY})")


### PR DESCRIPTION
`./cmake/Modules/FindCudnn.cmake` and `./cmake/Cuda.cmake` cannot find cudnn(cudnn 8 for cuda 11)

the following code
```
#define CUDNN_MAJOR 8
#define CUDNN_MINOR 0
#define CUDNN_PATCHLEVEL 4
```
had moved from `cudnn.h` to `cudnn_version.h`
I've modified the above cmake file to deal with it