### PR TITLE
Mac install update scripts

### DIFF
--- a/doc/installation/installation.md
+++ b/doc/installation/installation.md
@@ -297,10 +297,11 @@ If you only have an integrated Intel Graphics card, then it will most probably b
 ./build/examples/openpose/openpose.bin --num_gpu 1 --num_gpu_start 1
 ```
 
-Also as a side note, if the default installation fails (i.e., the one explained above), configure caffe manually to not include the `leveldb` dependency. Steps:
+Also as a side note, if the default installation (i.e., the one explained above) fails since it `cannot find vecLib`,
+or if you get a `Attempt to free invalid Pointer` runtime error, configure caffe manually to not include the `leveldb` dependency. Steps:
 - Re-create the build folder: `rm -rf build; mkdir build; cd build`.
 - `brew uninstall caffe` to remove the version of Caffe previously installed via cmake.
-- Follow the ####Problem with installing Caffe from homebrew#### in the [prerequisite.md](prerequisite.md#75) file, under Mac OS Prerequisites.
+- Follow the **Problem with installing Caffe from homebrew** in the [prerequisite.md](prerequisite.md#75) file, under Mac OS Prerequisites.
 - Run `cmake-gui` and click `Configure` and `Generate`.
 
 In addition, if you face an OpenCV error during compiling time similar to `fatal error: 'opencv2/highgui/highgui.hpp' file not found`, please apply the following patch (this error has been reported in the latest OSX 10.14):

--- a/doc/installation/installation.md
+++ b/doc/installation/installation.md
@@ -197,7 +197,7 @@ We add links to some community-based work based on OpenPose. Note: We do not sup
         - Option 1:
             - 1. (if necessary) Install the latest version of docker (There are extra steps, but if you're on Ubuntu, the main one is `sudo apt-get install docker-ce`.  Other steps can be found [here](https://phoenixnap.com/kb/how-to-install-docker-on-ubuntu-18-04) )
             - 2. `docker pull exsidius/openpose` - [Guide](https://github.com/gormonn/openpose-docker/blob/master/README.md)
-            - 3. [more details](https://cloud.docker.com/repository/docker/exsidius/openpose/general) 
+            - 3. [more details](https://cloud.docker.com/repository/docker/exsidius/openpose/general)
         - [Link 2](https://github.com/esemeniuc/openpose-docker), it claims to also include Python support. Read and post ONLY on [issue thread #1102](https://github.com/CMU-Perceptual-Computing-Lab/openpose/issues/1102).
         - [Link 3](https://github.com/ExSidius/openpose-docker/blob/master/Dockerfile).
         - [Link 4](https://cloud.docker.com/repository/docker/exsidius/openpose/general).
@@ -297,15 +297,11 @@ If you only have an integrated Intel Graphics card, then it will most probably b
 ./build/examples/openpose/openpose.bin --num_gpu 1 --num_gpu_start 1
 ```
 
-Also as a side note, if the default installation fails (i.e., the one explained above), install Caffe separately and set `BUILD_CAFFE` to false in the CMake config. Steps:
+Also as a side note, if the default installation fails (i.e., the one explained above), configure caffe manually to not include the `leveldb` dependency. Steps:
 - Re-create the build folder: `rm -rf build; mkdir build; cd build`.
 - `brew uninstall caffe` to remove the version of Caffe previously installed via cmake.
-- `brew install caffe` to install Caffe separately.
-- Run `cmake-gui` and make the following adjustments to the cmake config:
-    1. `BUILD_CAFFE` set to false.
-    2. `Caffe_INCLUDE_DIRS` set to `/usr/local/include/caffe`.
-    3. `Caffe_LIBS` set to `/usr/local/lib/libcaffe.dylib`.
-    4. Run `Configure` and `Generate` from CMake GUI.
+- Follow the ####Problem with installing Caffe from homebrew#### in the [prerequisite.md](prerequisite.md#75) file, under Mac OS Prerequisites.
+- Run `cmake-gui` and click `Configure` and `Generate`.
 
 In addition, if you face an OpenCV error during compiling time similar to `fatal error: 'opencv2/highgui/highgui.hpp' file not found`, please apply the following patch (this error has been reported in the latest OSX 10.14):
 ```bash

--- a/doc/installation/installation.md
+++ b/doc/installation/installation.md
@@ -301,7 +301,7 @@ Also as a side note, if the default installation (i.e., the one explained above)
 or if you get a `Attempt to free invalid Pointer` runtime error, configure caffe manually to not include the `leveldb` dependency. Steps:
 - Re-create the build folder: `rm -rf build; mkdir build; cd build`.
 - `brew uninstall caffe` to remove the version of Caffe previously installed via cmake.
-- Follow the **Problem with installing Caffe from homebrew** in the [prerequisite.md](prerequisite.md#75) file, under Mac OS Prerequisites.
+- Follow the **Problem with installing Caffe from homebrew** in the [prerequisite.md](prerequisites.md#problem-with-installing-caffe-from-homebrew) file, under Mac OS Prerequisites.
 - Run `cmake-gui` and click `Configure` and `Generate`.
 
 In addition, if you face an OpenCV error during compiling time similar to `fatal error: 'opencv2/highgui/highgui.hpp' file not found`, please apply the following patch (this error has been reported in the latest OSX 10.14):

--- a/doc/installation/prerequisites.md
+++ b/doc/installation/prerequisites.md
@@ -72,8 +72,10 @@ You might prefer to download them manually:
 2. Install **CMake GUI**: Run the command `brew cask install cmake`.
 3. Install **Caffe, OpenCV, and Caffe prerequisites**: Run `bash scripts/osx/install_deps.sh`.
 
+<a name="problem-with-installing-caffe-from-homebrew"></a>
 #### [Problem with installing Caffe from homebrew]:
-If you have installed Caffe from homebrew, you might run into an `invalid pointer error`. In such a case, the leveldb dependency of Caffe is causing an issue. There is a very simple fix.
+
+If you have installed Caffe from homebrew, you might run into an `Attempt to free invalid pointer`. In such a case, the **leveldb** dependency of Caffe is causing an issue. There is a very simple fix.
 
 Note: If you have not, uninstall the current Caffe bottle:
 `brew uninstall caffe`
@@ -108,7 +110,7 @@ find_path(vecLib_INCLUDE_DIR vecLib.h
           PATHS /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Accelerate.framework/Versions/Current/Frameworks/vecLib.framework/Headers/
           NO_DEFAULT_PATH)
 ```
-
+This will fix the `vecLib` not found issues when `BUILD_CAFFE` is run.
 Now we have to remove the `leveldb` dependency, and build without it. The `leveldb` dependency is the library that is causing the issue of `Attempt to Free Invalid Pointer`, not the `tcmalloc`. This is a documented issue on their [github repo](https://github.com/google/leveldb/issues/634).
 
 To do this we need to edit the `CMakeLists.txt` file for caffe.

--- a/doc/installation/prerequisites.md
+++ b/doc/installation/prerequisites.md
@@ -84,7 +84,7 @@ Go to the 3rd party folder and clone the caffe repo:
 ```
 cd 3rdparty
 rm -rf caffe
-git clone https://github.com/BVLC/caffe.git
+git clone https://github.com/CMU-Perceptual-Computing-Lab/caffe.git
 ```
 
 Now, we have to make a change to the Caffe cmake configurations:

--- a/scripts/osx/install_deps.sh
+++ b/scripts/osx/install_deps.sh
@@ -2,7 +2,7 @@ brew install openblas
 brew install -vd snappy leveldb gflags glog szip lmdb
 brew install hdf5 opencv
 # with Python pycaffe needs dependencies built from source
-#brew install --build-from-source --with-python -vd protobuf
+#brew install --build-from-source -vd protobuf
 #brew install --build-from-source -vd boost boost-python
 # without Python the usual installation suffices
 brew install protobuf boost


### PR DESCRIPTION
This version updates the docs for the proper installation on macOS systems.

`caffe` cannot be built as `vecLib` cannot be found:
The current patch relies on brew's `caffe` bottle. 
This is not a good approach.
On top of that, homebrew built `caffe` with `leveldb`, and as this [issue](https://github.com/google/leveldb/issues/634) highlights, `leveldb` causes an issue with `tcmalloc` that causes the runtime `Attempt to free Invalid Pointer` error.

This version specifies the correct `vecLib_INCLUDE_DIRS` in the pre-requisites documentation. Rather than not build `caffe` from scratch and rely on homebrew, this version fixes the `caffe` build process. 

Furthermore, it also shows to users how to build `caffe` without `leveldb`, which prevents the `tcmalloc` issue. 