### PR TITLE
Use GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,7 @@ jobs:
               NAME: U16-python-cmake-cpu
               WITH_PYTHON: true
               WITH_CUDA: false
+              WITH_CUDNN: false
               TRAVIS_OS_NAME: linux
 
           # Ubuntu 16.04 - Python - CMake - OpenCL
@@ -55,6 +56,7 @@ jobs:
               NAME: U16-python-cmake-opencl
               WITH_PYTHON: true
               WITH_CUDA: false
+              WITH_CUDNN: false
               WITH_OPEN_CL: true
               TRAVIS_OS_NAME: linux
 
@@ -65,6 +67,7 @@ jobs:
               NAME: U16-python-cmake-cpu-debug
               WITH_PYTHON: true
               WITH_CUDA: false
+              WITH_CUDNN: false
               WITH_DEBUG: true
               TRAVIS_OS_NAME: linux
 
@@ -76,6 +79,7 @@ jobs:
               WITH_PYTHON: true
               WITH_UNITY: true
               WITH_CUDA: false
+              WITH_CUDNN: false
               TRAVIS_OS_NAME: linux
 
           # Mac OSX
@@ -85,6 +89,7 @@ jobs:
             env:
               NAME: OSX-python-cmake-cpu
               WITH_CUDA: false
+              WITH_CUDNN: false
               WITH_PYTHON: true
               TRAVIS_OS_NAME: osx
 
@@ -94,6 +99,7 @@ jobs:
             env:
               NAME: OSX-default-cmake-opencl
               WITH_CUDA: false
+              WITH_CUDNN: false
               WITH_OPEN_CL: true
               TRAVIS_OS_NAME: osx
 
@@ -103,6 +109,7 @@ jobs:
             env:
               NAME: OSX-python-cmake-cpu-debug
               WITH_CUDA: false
+              WITH_CUDNN: false
               WITH_PYTHON: true
               WITH_DEBUG: true
               TRAVIS_OS_NAME: osx
@@ -113,6 +120,7 @@ jobs:
             env:
               NAME: OSX-python-cmake-cpu-unity
               WITH_CUDA: false
+              WITH_CUDNN: false
               WITH_PYTHON: true
               WITH_UNITY: true
               TRAVIS_OS_NAME: osx
@@ -123,6 +131,7 @@ jobs:
             env:
               NAME: OSX-default-cmake-cpu
               WITH_CUDA: false
+              WITH_CUDNN: false
               TRAVIS_OS_NAME: osx
 
           # Ubuntu (others)
@@ -132,6 +141,7 @@ jobs:
             env:
               NAME: U16-default-cmake-cpu
               WITH_CUDA: false
+              WITH_CUDNN: false
               TRAVIS_OS_NAME: linux
 
           # Ubuntu 16.04 - Default - Make - CUDA
@@ -149,6 +159,7 @@ jobs:
           #   env:
           #     NAME: U16-default-cmake-cpu-mkl
           #     WITH_CUDA: false
+          #     WITH_CUDNN: false
           #     WITH_MKL: true
           #     TRAVIS_OS_NAME: linux
 
@@ -159,6 +170,7 @@ jobs:
           #     NAME: U16-python-cmake-opencl
           #     WITH_PYTHON: true
           #     WITH_CUDA: false
+          #     WITH_CUDNN: false
           #     WITH_OPEN_CL: true
           #     TRAVIS_OS_NAME: linux
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -188,6 +188,8 @@ jobs:
       with:
         submodules: recursive
     - uses: actions/setup-python@v2
+      with:
+        python-version: 2.x
       if: ${{ matrix.env.WITH_PYTHON }}
     - name: Docs APT packages
       run: sudo apt-get -yq install doxygen doxygen-doc doxygen-latex doxygen-gui graphviz

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -176,8 +176,6 @@ jobs:
         submodules: recursive
     - uses: actions/setup-python@v2
       if: ${{ matrix.env.WITH_PYTHON }}
-    - name: Export CI
-      run: export CI
     - name: Docs APT packages
       run: sudo apt-get -yq install doxygen doxygen-doc doxygen-latex doxygen-gui graphviz
       if: ${{ matrix.DOCS }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -176,6 +176,8 @@ jobs:
         submodules: recursive
     - uses: actions/setup-python@v2
       if: ${{ matrix.env.WITH_PYTHON }}
+    - name: Export CI
+      run: export CI
     - name: Docs APT packages
       run: |
         sudo apt-get install doxygen doxygen-doc doxygen-latex doxygen-gui graphviz

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -186,6 +186,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
+        fetch-depth: 0
         submodules: recursive
     - uses: actions/setup-python@v2
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -179,8 +179,7 @@ jobs:
     - name: Export CI
       run: export CI
     - name: Docs APT packages
-      run: |
-        sudo apt-get install doxygen doxygen-doc doxygen-latex doxygen-gui graphviz
+      run: sudo apt-get install doxygen doxygen-doc doxygen-latex doxygen-gui graphviz
       if: ${{ matrix.DOCS }}
     - name: Install (Linux)
       run: scripts/travis/install_deps_ubuntu.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,6 @@ env:
   GH_REPO_NAME: ${{ github.event.repository.name }}
   DOXYFILE: ${{ github.workspace }}/scripts/doc_autogeneration.doxygen
   GH_REPO_REF: ${{ github.repositoryUrl }}
-  TRAVIS_BUILD_DIR: ${{ github.workspace }}
 
 jobs:
   build:
@@ -191,8 +190,23 @@ jobs:
       run: scripts/travis/run_make.sh
     - name: Tests
       run: scripts/travis/run_tests.sh
-    - name: Docs
+    - name: Generate docs
       run: |
         cd ${{ github.workspace }}
-        ./scripts/generate_gh_pages.sh
+        echo 'Generating Doxygen code documentation...'
+        echo "INPUT                  = ${{ github.workspace }}/README.md ${{ github.workspace }}/include/openpose/" >> $DOXYFILE
+        echo "USE_MDFILE_AS_MAINPAGE = ${{ github.workspace }}/README.md" >> $DOXYFILE
+        echo "OUTPUT_DIRECTORY       = " >> $DOXYFILE
+        doxygen $DOXYFILE 2>&1 | tee doxygen.log
+        echo "" > html/.nojekyll
+        cp doxygen.log html/doxygen.log
+      if: ${{ matrix.DOCS }}
+    - name: Deploy Docs
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: html
+        destination_dir: .
+        enable_jekyll: false
+        force_orphan: true
       if: ${{ matrix.DOCS }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,198 @@
+name: CI
+
+on:
+  push:
+    branches: master
+  pull_request:
+    branches: master
+
+env:
+  GH_REPO_NAME: ${{ github.event.repository.name }}
+  DOXYFILE: ${{ github.workspace }}/scripts/doc_autogeneration.doxygen
+  GH_REPO_REF: ${{ github.repositoryUrl }}
+  TRAVIS_BUILD_DIR: ${{ github.workspace }}
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    env: ${{ matrix.env }}
+    strategy:
+      matrix:
+        include:
+          # Ubuntu 16.04
+          # Ubuntu 16.04 - Default - CMake - CUDA
+          - os: ubuntu-16.04
+            os_name: linux
+            env:
+              NAME: U16-default-cmake-cuda8
+              TRAVIS_OS_NAME: linux
+
+          # Ubuntu 16.04 - Python - CMake - CUDA
+          - os: ubuntu-16.04
+            os_name: linux
+            env:
+              NAME: U16-python-cmake-cuda8
+              WITH_PYTHON: true
+              TRAVIS_OS_NAME: linux
+              TRAVIS_BUILD_NUMBER: ${{ github.run_number }}
+              TRAVIS_COMMIT: ${{ github.sha }}
+            DOCS: true
+
+          # Ubuntu 16.04 - Python - CMake - CPU
+          - os: ubuntu-16.04
+            os_name: linux
+            env:
+              NAME: U16-python-cmake-cpu
+              WITH_PYTHON: true
+              WITH_CUDA: false
+              TRAVIS_OS_NAME: linux
+
+          # Ubuntu 16.04 - Python - CMake - OpenCL
+          - os: ubuntu-16.04
+            os_name: linux
+            env:
+              NAME: U16-python-cmake-opencl
+              WITH_PYTHON: true
+              WITH_CUDA: false
+              WITH_OPEN_CL: true
+              TRAVIS_OS_NAME: linux
+
+          # Ubuntu 16.04 - Python - CMake - CPU - Debug
+          - os: ubuntu-16.04
+            os_name: linux
+            env:
+              NAME: U16-python-cmake-cpu-debug
+              WITH_PYTHON: true
+              WITH_CUDA: false
+              WITH_DEBUG: true
+              TRAVIS_OS_NAME: linux
+
+          # Ubuntu 16.04 - Python - CMake - CPU - Unity
+          - os: ubuntu-16.04
+            os_name: linux
+            env:
+              NAME: U16-python-cmake-cpu-unity
+              WITH_PYTHON: true
+              WITH_UNITY: true
+              WITH_CUDA: false
+              TRAVIS_OS_NAME: linux
+
+          # Mac OSX
+          # Mac OSX - Python - CMake - CPU
+          - os: macos-10.15
+            os_name: osx
+            env:
+              NAME: OSX-python-cmake-cpu
+              WITH_CUDA: false
+              WITH_PYTHON: true
+              TRAVIS_OS_NAME: osx
+
+          # Mac OSX - Python - CMake - OpenCL
+          - os: macos-10.15
+            os_name: osx
+            env:
+              NAME: OSX-default-cmake-opencl
+              WITH_CUDA: false
+              WITH_OPEN_CL: true
+              TRAVIS_OS_NAME: osx
+
+          # Mac OSX - Python - CMake - CPU - Debug
+          - os: macos-10.15
+            os_name: osx
+            env:
+              NAME: OSX-python-cmake-cpu-debug
+              WITH_CUDA: false
+              WITH_PYTHON: true
+              WITH_DEBUG: true
+              TRAVIS_OS_NAME: osx
+
+          # Mac OSX - Python - CMake - CPU - Unity
+          - os: macos-10.15
+            os_name: osx
+            env:
+              NAME: OSX-python-cmake-cpu-unity
+              WITH_CUDA: false
+              WITH_PYTHON: true
+              WITH_UNITY: true
+              TRAVIS_OS_NAME: osx
+
+          # Mac OSX - Default - CMake - CPU
+          - os: macos-10.15
+            os_name: osx
+            env:
+              NAME: OSX-default-cmake-cpu
+              WITH_CUDA: false
+              TRAVIS_OS_NAME: osx
+
+          # Ubuntu (others)
+          # Ubuntu 16.04 - Default - CMake - CPU
+          - os: ubuntu-16.04
+            os_name: linux
+            env:
+              NAME: U16-default-cmake-cpu
+              WITH_CUDA: false
+              TRAVIS_OS_NAME: linux
+
+          # Ubuntu 16.04 - Default - Make - CUDA
+          - os: ubuntu-16.04
+            os_name: linux
+            env:
+              NAME: U16-default-make-cuda8
+              WITH_CMAKE: false
+              TRAVIS_OS_NAME: linux
+
+          # # TO-DO: To be implemented
+          # # Ubuntu 16.04 - Default - CMake - CPU MKL
+          # - os: ubuntu-16.04
+          #   os_name: linux
+          #   env:
+          #     NAME: U16-default-cmake-cpu-mkl
+          #     WITH_CUDA: false
+          #     WITH_MKL: true
+          #     TRAVIS_OS_NAME: linux
+
+          # # Ubuntu 16.04 - Python - CMake - OpenCL
+          # - os: ubuntu-16.04
+          #   os_name: linux
+          #   env:
+          #     NAME: U16-python-cmake-opencl
+          #     WITH_PYTHON: true
+          #     WITH_CUDA: false
+          #     WITH_OPEN_CL: true
+          #     TRAVIS_OS_NAME: linux
+
+          # # Unnecessary/redundant ones
+          # # Ubuntu 16.04 - Default - CMake - CUDA - no cuDNN
+          # - os: ubuntu-16.04
+          #   os_name: linux
+          #   env:
+          #     NAME: U16-default-cmake-cuda8-nocudnn
+          #     WITH_CUDNN: false
+          #     TRAVIS_OS_NAME: linux
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Docs APT packages
+      run: |
+        sudo apt-get install doxygen doxygen-doc doxygen-latex doxygen-gui graphviz
+      if: ${{ matrix.DOCS }}
+    - name: Install (Linux)
+      run: scripts/travis/install_deps_ubuntu.sh
+      if: ${{ matrix.os_name == "linux" }}
+    - name: Install (Mac OS)
+      run: scripts/travis/install_deps_osx.sh
+      if: ${{ matrix.os_name == "osx" }}
+
+    - name: Configure
+      run: scripts/travis/configure.sh
+    - name: Make
+      run: scripts/travis/run_make.sh
+    - name: Tests
+      run: scripts/travis/run_tests.sh
+    - name: Docs
+      run: |
+        cd ${{ github.workspace }}
+        ./scripts/generate_gh_pages.sh
+      if: ${{ matrix.DOCS }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -180,10 +180,10 @@ jobs:
       if: ${{ matrix.DOCS }}
     - name: Install (Linux)
       run: scripts/travis/install_deps_ubuntu.sh
-      if: ${{ matrix.os_name == "linux" }}
+      if: ${{ matrix.os_name == 'linux' }}
     - name: Install (Mac OS)
       run: scripts/travis/install_deps_osx.sh
-      if: ${{ matrix.os_name == "osx" }}
+      if: ${{ matrix.os_name == 'osx' }}
 
     - name: Configure
       run: scripts/travis/configure.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -174,6 +174,8 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: recursive
+    - uses: actions/setup-python@v2
+      if: ${{ matrix.env.WITH_PYTHON }}
     - name: Docs APT packages
       run: |
         sudo apt-get install doxygen doxygen-doc doxygen-latex doxygen-gui graphviz

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env: ${{ matrix.env }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           # Ubuntu 16.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,7 @@ env:
 
 jobs:
   build:
+    name: ${{ matrix.env.NAME }}
     runs-on: ${{ matrix.os }}
     env: ${{ matrix.env }}
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -179,7 +179,7 @@ jobs:
     - name: Export CI
       run: export CI
     - name: Docs APT packages
-      run: sudo apt-get install doxygen doxygen-doc doxygen-latex doxygen-gui graphviz
+      run: sudo apt-get -yq install doxygen doxygen-doc doxygen-latex doxygen-gui graphviz
       if: ${{ matrix.DOCS }}
     - name: Install (Linux)
       run: scripts/travis/install_deps_ubuntu.sh

--- a/scripts/osx/install_deps.sh
+++ b/scripts/osx/install_deps.sh
@@ -8,5 +8,5 @@ brew install hdf5 opencv
 brew install protobuf boost
 brew install cmake
 brew install viennacl
-sudo pip install numpy
-sudo pip install "opencv-python<4.3"
+sudo python2 -m pip install numpy
+sudo python2 -m pip install "opencv-python<4.3"

--- a/scripts/osx/install_deps.sh
+++ b/scripts/osx/install_deps.sh
@@ -9,4 +9,4 @@ brew install protobuf boost
 brew install cmake
 brew install viennacl
 sudo pip install numpy
-sudo pip install opencv-python
+sudo pip install "opencv-python<4.3"

--- a/scripts/travis/configure.sh
+++ b/scripts/travis/configure.sh
@@ -2,14 +2,15 @@
 
 # Configure the project
 
-BASEDIR=$(dirname $0)
-source $BASEDIR/defaults.sh
+BASEDIR=$(dirname "$0")
+source "$BASEDIR"/defaults.sh
 
 echo "WITH_CMAKE = ${WITH_CMAKE}."
-if [[ $WITH_CMAKE == true ]] ; then
+if [[ "$WITH_CMAKE" == "true" ]]
+then
   echo "Running CMake configuration..."
-  source $BASEDIR/configure_cmake.sh
+  source "$BASEDIR"/configure_cmake.sh
 else
   echo "Running Makefile configuration..."
-  source $BASEDIR/configure_make.sh
+  source "$BASEDIR"/configure_make.sh
 fi

--- a/scripts/travis/defaults.sh
+++ b/scripts/travis/defaults.sh
@@ -12,6 +12,12 @@ WITH_MKL=${WITH_MKL:-false}
 WITH_UNITY=${WITH_UNITY:-false}
 WITH_DEBUG=${WITH_DEBUG:-false}
 
+if [[ $WITH_CUDA == false ]] && [[ $WITH_CUDNN == true ]]
+then
+  echo "CUDNN only possible in combination with CUDA, setting WITH_CUDNN to false"
+  WITH_CUDNN=false
+fi
+
 # Examples should be run (Travis not compatible with GPU code)
 # if [[ $WITH_CMAKE == true ]] && [[ $WITH_PYTHON == true ]] && [[ $WITH_CUDA == false ]] && [[ $WITH_OPEN_CL == false ]] && [[ $WITH_MKL == false ]]; then
 if [[ $WITH_CUDA == false ]] && [[ $WITH_OPEN_CL == false ]] && [[ $WITH_UNITY == false ]]; then

--- a/scripts/travis/install_deps_ubuntu.sh
+++ b/scripts/travis/install_deps_ubuntu.sh
@@ -8,9 +8,14 @@ source "$BASEDIR"/defaults.sh
 
 if [[ "$WITH_CUDA" == "true" ]]
 then
-  source scripts/ubuntu/install_deps_and_cuda.sh
-else
-  source scripts/ubuntu/install_deps.sh
+  source scripts/ubuntu/install_cuda.sh
 fi
+if [[ "$WITH_CUDNN" == "true" ]]
+then
+  source scripts/ubuntu/install_cudnn.sh
+fi
+
+source scripts/ubuntu/install_deps.sh
+
 sudo apt-get -yq  install libatlas-base-dev
 sudo apt-get -yq  install libopencv-dev

--- a/scripts/travis/install_deps_ubuntu.sh
+++ b/scripts/travis/install_deps_ubuntu.sh
@@ -3,13 +3,14 @@
 # Install dependencies for Ubuntu
 echo "Running on ${TRAVIS_OS_NAME} OS."
 
-BASEDIR=$(dirname $0)
-source $BASEDIR/defaults.sh
+BASEDIR=$(dirname "$0")
+source "$BASEDIR"/defaults.sh
 
-if [[ $WITH_CUDA == true ]] ; then
-  sudo bash scripts/ubuntu/install_deps_and_cuda.sh
+if [[ "$WITH_CUDA" == "true" ]]
+then
+  source scripts/ubuntu/install_deps_and_cuda.sh
 else
-  sudo bash scripts/ubuntu/install_deps.sh
+  source scripts/ubuntu/install_deps.sh
 fi
-sudo apt-get -y install libatlas-base-dev
-sudo apt-get -y install libopencv-dev
+sudo apt-get -yq  install libatlas-base-dev
+sudo apt-get -yq  install libopencv-dev

--- a/scripts/travis/install_deps_ubuntu.sh
+++ b/scripts/travis/install_deps_ubuntu.sh
@@ -17,5 +17,4 @@ fi
 
 source scripts/ubuntu/install_deps.sh
 
-sudo apt-get -yq  install libatlas-base-dev
 sudo apt-get -yq  install libopencv-dev

--- a/scripts/travis/run_tests.sh
+++ b/scripts/travis/run_tests.sh
@@ -95,7 +95,10 @@ if [[ $RUN_EXAMPLES == true ]] ; then
   if [[ $WITH_PYTHON == true ]] ; then
     echo "Tutorial API Python: OpenPose demo..."
     cd build/examples/tutorial_api_python
-    python openpose_python.py --image_dir ../../../examples/media/ --net_resolution -1x32 --write_json output/ --write_images output/ --display 0
+    PYTHON_EXE=python2
+    [[ "${TRAVIS_OS_NAME}" == "linux" ]] && [[ "$(lsb_release -r)" == *"20."* ]] && PYTHON_EXE=python3
+    echo "Using python: ${PYTHON_EXE}"
+    ${PYTHON_EXE} openpose_python.py --image_dir ../../../examples/media/ --net_resolution -1x32 --write_json output/ --write_images output/ --display 0
     echo " "
     # Note: All Python examples require GUI
   fi

--- a/scripts/ubuntu/install_cuda.sh
+++ b/scripts/ubuntu/install_cuda.sh
@@ -16,13 +16,13 @@ if [[ $ubuntu_version == *"14."* ]]; then
   wget -c "https://developer.nvidia.com/compute/cuda/8.0/Prod2/local_installers/cuda-repo-ubuntu1404-8-0-local-ga2_8.0.61-1_amd64-deb" ${WGET_VERBOSE}
   sudo dpkg --install cuda-repo-ubuntu1404-8-0-local-ga2_8.0.61-1_amd64-deb
   sudo apt-get update
-  sudo apt-get install cuda-8-0
+  sudo apt-get -yq install cuda-8-0
 elif [[ $ubuntu_version == *"16."* ]]; then
   echo "wget -c \"https://developer.nvidia.com/compute/cuda/8.0/Prod2/local_installers/cuda-repo-ubuntu1604-8-0-local-ga2_8.0.61-1_amd64-deb\" ${WGET_VERBOSE}"
   wget -c "https://developer.nvidia.com/compute/cuda/8.0/Prod2/local_installers/cuda-repo-ubuntu1604-8-0-local-ga2_8.0.61-1_amd64-deb" ${WGET_VERBOSE}
   sudo dpkg --install cuda-repo-ubuntu1604-8-0-local-ga2_8.0.61-1_amd64-deb
   sudo apt-get update
-  sudo apt-get install cuda-8-0
+  sudo apt-get -yq install cuda-8-0
 # Install CUDA 10.0
 elif [[ $ubuntu_version == *"18."* ]]; then
   echo "wget -c \"https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-ubuntu1804.pin\" ${WGET_VERBOSE}"
@@ -33,7 +33,7 @@ elif [[ $ubuntu_version == *"18."* ]]; then
   sudo dpkg -i cuda-repo-ubuntu1804-10-2-local-10.2.89-440.33.01_1.0-1_amd64.deb
   sudo apt-key add /var/cuda-repo-10-2-local-10.2.89-440.33.01/7fa2af80.pub
   sudo apt-get update
-  sudo apt-get -y install cuda
+  sudo apt-get -yq install cuda
 # Install CUDA 11.0
 elif [[ $ubuntu_version == *"20."* ]]; then
   echo "wget -c \"https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin\" ${WGET_VERBOSE}"
@@ -44,6 +44,6 @@ elif [[ $ubuntu_version == *"20."* ]]; then
   sudo dpkg -i cuda-repo-ubuntu2004-11-0-local_11.0.3-450.51.06-1_amd64.deb
   sudo apt-key add /var/cuda-repo-ubuntu2004-11-0-local/7fa2af80.pub
   sudo apt-get update
-  sudo apt-get -y install cuda
+  sudo apt-get -yq install cuda
 fi
 # sudo apt-get install cuda

--- a/scripts/ubuntu/install_cuda.sh
+++ b/scripts/ubuntu/install_cuda.sh
@@ -12,19 +12,23 @@ fi
 ubuntu_version="$(lsb_release -r)"
 sudo apt-get update && sudo apt-get install wget -y --no-install-recommends
 if [[ $ubuntu_version == *"14."* ]]; then
+  echo "wget -c \"https://developer.nvidia.com/compute/cuda/8.0/Prod2/local_installers/cuda-repo-ubuntu1404-8-0-local-ga2_8.0.61-1_amd64-deb\" ${WGET_VERBOSE}"
   wget -c "https://developer.nvidia.com/compute/cuda/8.0/Prod2/local_installers/cuda-repo-ubuntu1404-8-0-local-ga2_8.0.61-1_amd64-deb" ${WGET_VERBOSE}
   sudo dpkg --install cuda-repo-ubuntu1404-8-0-local-ga2_8.0.61-1_amd64-deb
   sudo apt-get update
   sudo apt-get install cuda-8-0
 elif [[ $ubuntu_version == *"16."* ]]; then
+  echo "wget -c \"https://developer.nvidia.com/compute/cuda/8.0/Prod2/local_installers/cuda-repo-ubuntu1604-8-0-local-ga2_8.0.61-1_amd64-deb\" ${WGET_VERBOSE}"
   wget -c "https://developer.nvidia.com/compute/cuda/8.0/Prod2/local_installers/cuda-repo-ubuntu1604-8-0-local-ga2_8.0.61-1_amd64-deb" ${WGET_VERBOSE}
   sudo dpkg --install cuda-repo-ubuntu1604-8-0-local-ga2_8.0.61-1_amd64-deb
   sudo apt-get update
   sudo apt-get install cuda-8-0
 # Install CUDA 10.0
 elif [[ $ubuntu_version == *"18."* ]]; then
+  echo "wget -c \"https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-ubuntu1804.pin\" ${WGET_VERBOSE}"
   wget -c "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-ubuntu1804.pin" ${WGET_VERBOSE}
   sudo mv cuda-ubuntu1804.pin /etc/apt/preferences.d/cuda-repository-pin-600
+  echo "wget \"http://developer.download.nvidia.com/compute/cuda/10.2/Prod/local_installers/cuda-repo-ubuntu1804-10-2-local-10.2.89-440.33.01_1.0-1_amd64.deb\" ${WGET_VERBOSE}"
   wget "http://developer.download.nvidia.com/compute/cuda/10.2/Prod/local_installers/cuda-repo-ubuntu1804-10-2-local-10.2.89-440.33.01_1.0-1_amd64.deb" ${WGET_VERBOSE}
   sudo dpkg -i cuda-repo-ubuntu1804-10-2-local-10.2.89-440.33.01_1.0-1_amd64.deb
   sudo apt-key add /var/cuda-repo-10-2-local-10.2.89-440.33.01/7fa2af80.pub
@@ -32,8 +36,10 @@ elif [[ $ubuntu_version == *"18."* ]]; then
   sudo apt-get -y install cuda
 # Install CUDA 11.0
 elif [[ $ubuntu_version == *"20."* ]]; then
+  echo "wget -c \"https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin\" ${WGET_VERBOSE}"
   wget -c "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin" ${WGET_VERBOSE}
   sudo mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600
+  echo "wget \"https://developer.download.nvidia.com/compute/cuda/11.0.3/local_installers/cuda-repo-ubuntu2004-11-0-local_11.0.3-450.51.06-1_amd64.deb\" ${WGET_VERBOSE}"
   wget "https://developer.download.nvidia.com/compute/cuda/11.0.3/local_installers/cuda-repo-ubuntu2004-11-0-local_11.0.3-450.51.06-1_amd64.deb" ${WGET_VERBOSE}
   sudo dpkg -i cuda-repo-ubuntu2004-11-0-local_11.0.3-450.51.06-1_amd64.deb
   sudo apt-key add /var/cuda-repo-ubuntu2004-11-0-local/7fa2af80.pub

--- a/scripts/ubuntu/install_cuda.sh
+++ b/scripts/ubuntu/install_cuda.sh
@@ -10,7 +10,7 @@ fi
 
 # Install CUDA 8.0
 UBUNTU_VERSION="$(lsb_release -r)"
-sudo apt-get update && sudo apt-get install wget -y --no-install-recommends
+sudo apt-get update && sudo apt-get -yq install wget --no-install-recommends
 if [[ $UBUNTU_VERSION == *"14."* ]]; then
   echo "wget -c \"https://developer.nvidia.com/compute/cuda/8.0/Prod2/local_installers/cuda-repo-ubuntu1404-8-0-local-ga2_8.0.61-1_amd64-deb\" ${WGET_VERBOSE}"
   wget -c "https://developer.nvidia.com/compute/cuda/8.0/Prod2/local_installers/cuda-repo-ubuntu1404-8-0-local-ga2_8.0.61-1_amd64-deb" ${WGET_VERBOSE}

--- a/scripts/ubuntu/install_cuda.sh
+++ b/scripts/ubuntu/install_cuda.sh
@@ -9,22 +9,22 @@ then
 fi
 
 # Install CUDA 8.0
-ubuntu_version="$(lsb_release -r)"
+UBUNTU_VERSION="$(lsb_release -r)"
 sudo apt-get update && sudo apt-get install wget -y --no-install-recommends
-if [[ $ubuntu_version == *"14."* ]]; then
+if [[ $UBUNTU_VERSION == *"14."* ]]; then
   echo "wget -c \"https://developer.nvidia.com/compute/cuda/8.0/Prod2/local_installers/cuda-repo-ubuntu1404-8-0-local-ga2_8.0.61-1_amd64-deb\" ${WGET_VERBOSE}"
   wget -c "https://developer.nvidia.com/compute/cuda/8.0/Prod2/local_installers/cuda-repo-ubuntu1404-8-0-local-ga2_8.0.61-1_amd64-deb" ${WGET_VERBOSE}
   sudo dpkg --install cuda-repo-ubuntu1404-8-0-local-ga2_8.0.61-1_amd64-deb
   sudo apt-get update
   sudo apt-get -yq install cuda-8-0
-elif [[ $ubuntu_version == *"16."* ]]; then
+elif [[ $UBUNTU_VERSION == *"16."* ]]; then
   echo "wget -c \"https://developer.nvidia.com/compute/cuda/8.0/Prod2/local_installers/cuda-repo-ubuntu1604-8-0-local-ga2_8.0.61-1_amd64-deb\" ${WGET_VERBOSE}"
   wget -c "https://developer.nvidia.com/compute/cuda/8.0/Prod2/local_installers/cuda-repo-ubuntu1604-8-0-local-ga2_8.0.61-1_amd64-deb" ${WGET_VERBOSE}
   sudo dpkg --install cuda-repo-ubuntu1604-8-0-local-ga2_8.0.61-1_amd64-deb
   sudo apt-get update
   sudo apt-get -yq install cuda-8-0
 # Install CUDA 10.0
-elif [[ $ubuntu_version == *"18."* ]]; then
+elif [[ $UBUNTU_VERSION == *"18."* ]]; then
   echo "wget -c \"https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-ubuntu1804.pin\" ${WGET_VERBOSE}"
   wget -c "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-ubuntu1804.pin" ${WGET_VERBOSE}
   sudo mv cuda-ubuntu1804.pin /etc/apt/preferences.d/cuda-repository-pin-600
@@ -35,7 +35,7 @@ elif [[ $ubuntu_version == *"18."* ]]; then
   sudo apt-get update
   sudo apt-get -yq install cuda
 # Install CUDA 11.0
-elif [[ $ubuntu_version == *"20."* ]]; then
+elif [[ $UBUNTU_VERSION == *"20."* ]]; then
   echo "wget -c \"https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin\" ${WGET_VERBOSE}"
   wget -c "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin" ${WGET_VERBOSE}
   sudo mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600

--- a/scripts/ubuntu/install_cuda.sh
+++ b/scripts/ubuntu/install_cuda.sh
@@ -3,33 +3,38 @@
 echo "NOTE: This script assumes Ubuntu 20 or 18 (Nvidia Graphics card >= 10XX), as well as 16 or 14 (card up to 10XX)."
 echo "Otherwise, install it by yourself or it might fail."
 
+if [[ "$CI" == "true" ]]
+then
+    WGET_VERBOSE="--no-verbose"
+fi
+
 # Install CUDA 8.0
 ubuntu_version="$(lsb_release -r)"
 sudo apt-get update && sudo apt-get install wget -y --no-install-recommends
 if [[ $ubuntu_version == *"14."* ]]; then
-  wget -c "https://developer.nvidia.com/compute/cuda/8.0/Prod2/local_installers/cuda-repo-ubuntu1404-8-0-local-ga2_8.0.61-1_amd64-deb"
+  wget -c "https://developer.nvidia.com/compute/cuda/8.0/Prod2/local_installers/cuda-repo-ubuntu1404-8-0-local-ga2_8.0.61-1_amd64-deb" ${WGET_VERBOSE}
   sudo dpkg --install cuda-repo-ubuntu1404-8-0-local-ga2_8.0.61-1_amd64-deb
   sudo apt-get update
   sudo apt-get install cuda-8-0
 elif [[ $ubuntu_version == *"16."* ]]; then
-  wget -c "https://developer.nvidia.com/compute/cuda/8.0/Prod2/local_installers/cuda-repo-ubuntu1604-8-0-local-ga2_8.0.61-1_amd64-deb"
+  wget -c "https://developer.nvidia.com/compute/cuda/8.0/Prod2/local_installers/cuda-repo-ubuntu1604-8-0-local-ga2_8.0.61-1_amd64-deb" ${WGET_VERBOSE}
   sudo dpkg --install cuda-repo-ubuntu1604-8-0-local-ga2_8.0.61-1_amd64-deb
   sudo apt-get update
   sudo apt-get install cuda-8-0
 # Install CUDA 10.0
 elif [[ $ubuntu_version == *"18."* ]]; then
-  wget -c "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-ubuntu1804.pin"
+  wget -c "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-ubuntu1804.pin" ${WGET_VERBOSE}
   sudo mv cuda-ubuntu1804.pin /etc/apt/preferences.d/cuda-repository-pin-600
-  wget http://developer.download.nvidia.com/compute/cuda/10.2/Prod/local_installers/cuda-repo-ubuntu1804-10-2-local-10.2.89-440.33.01_1.0-1_amd64.deb
+  wget "http://developer.download.nvidia.com/compute/cuda/10.2/Prod/local_installers/cuda-repo-ubuntu1804-10-2-local-10.2.89-440.33.01_1.0-1_amd64.deb" ${WGET_VERBOSE}
   sudo dpkg -i cuda-repo-ubuntu1804-10-2-local-10.2.89-440.33.01_1.0-1_amd64.deb
   sudo apt-key add /var/cuda-repo-10-2-local-10.2.89-440.33.01/7fa2af80.pub
   sudo apt-get update
   sudo apt-get -y install cuda
 # Install CUDA 11.0
 elif [[ $ubuntu_version == *"20."* ]]; then
-  wget -c "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin"
+  wget -c "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin" ${WGET_VERBOSE}
   sudo mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600
-  wget "https://developer.download.nvidia.com/compute/cuda/11.0.3/local_installers/cuda-repo-ubuntu2004-11-0-local_11.0.3-450.51.06-1_amd64.deb"
+  wget "https://developer.download.nvidia.com/compute/cuda/11.0.3/local_installers/cuda-repo-ubuntu2004-11-0-local_11.0.3-450.51.06-1_amd64.deb" ${WGET_VERBOSE}
   sudo dpkg -i cuda-repo-ubuntu2004-11-0-local_11.0.3-450.51.06-1_amd64.deb
   sudo apt-key add /var/cuda-repo-ubuntu2004-11-0-local/7fa2af80.pub
   sudo apt-get update

--- a/scripts/ubuntu/install_cudnn.sh
+++ b/scripts/ubuntu/install_cudnn.sh
@@ -9,10 +9,11 @@ fi
 
 # Install cuDNN 5.1
 if [[ $UBUNTU_VERSION == *"14."* ]] || [[ $UBUNTU_VERSION == *"15."* ]] || [[ $UBUNTU_VERSION == *"16."* ]]; then
-	CUDNN_URL="http://developer.download.nvidia.com/compute/redist/cudnn/v5.1/cudnn-8.0-linux-x64-v5.1.tgz"
-	wget -c ${CUDNN_URL} ${WGET_VERBOSE}
-	sudo tar -xzf cudnn-8.0-linux-x64-v5.1.tgz -C /usr/local
-	rm cudnn-8.0-linux-x64-v5.1.tgz && sudo ldconfig
+    CUDNN_URL="http://developer.download.nvidia.com/compute/redist/cudnn/v5.1/cudnn-8.0-linux-x64-v5.1.tgz"
+    echo "wget -c ${CUDNN_URL} ${WGET_VERBOSE}"
+    wget -c ${CUDNN_URL} ${WGET_VERBOSE}
+    sudo tar -xzf cudnn-8.0-linux-x64-v5.1.tgz -C /usr/local
+    rm cudnn-8.0-linux-x64-v5.1.tgz && sudo ldconfig
 else
-	echo "cuDNN NOT INSTALLED! Ubuntu 16 or 14 not found. Install cuDNN manually from 'https://developer.nvidia.com/cudnn'."
+    echo "cuDNN NOT INSTALLED! Ubuntu 16 or 14 not found. Install cuDNN manually from 'https://developer.nvidia.com/cudnn'."
 fi

--- a/scripts/ubuntu/install_cudnn.sh
+++ b/scripts/ubuntu/install_cudnn.sh
@@ -2,10 +2,15 @@
 
 echo "This script assumes Ubuntu 16 or 14 and Nvidia Graphics card up to 10XX. Otherwise, it will fail."
 
+if [[ "$CI" == "true" ]]
+then
+    WGET_VERBOSE="--no-verbose"
+fi
+
 # Install cuDNN 5.1
 if [[ $UBUNTU_VERSION == *"14."* ]] || [[ $UBUNTU_VERSION == *"15."* ]] || [[ $UBUNTU_VERSION == *"16."* ]]; then
 	CUDNN_URL="http://developer.download.nvidia.com/compute/redist/cudnn/v5.1/cudnn-8.0-linux-x64-v5.1.tgz"
-	wget -c ${CUDNN_URL}
+	wget -c ${CUDNN_URL} ${WGET_VERBOSE}
 	sudo tar -xzf cudnn-8.0-linux-x64-v5.1.tgz -C /usr/local
 	rm cudnn-8.0-linux-x64-v5.1.tgz && sudo ldconfig
 else

--- a/scripts/ubuntu/install_cudnn.sh
+++ b/scripts/ubuntu/install_cudnn.sh
@@ -8,6 +8,7 @@ then
 fi
 
 # Install cuDNN 5.1
+UBUNTU_VERSION="$(lsb_release -r)"
 if [[ $UBUNTU_VERSION == *"14."* ]] || [[ $UBUNTU_VERSION == *"15."* ]] || [[ $UBUNTU_VERSION == *"16."* ]]; then
     CUDNN_URL="http://developer.download.nvidia.com/compute/redist/cudnn/v5.1/cudnn-8.0-linux-x64-v5.1.tgz"
     echo "wget -c ${CUDNN_URL} ${WGET_VERBOSE}"

--- a/scripts/ubuntu/install_deps.sh
+++ b/scripts/ubuntu/install_deps.sh
@@ -16,12 +16,14 @@ sudo apt-get -yq install libgflags-dev libgoogle-glog-dev liblmdb-dev
 if [[ $UBUNTU_VERSION == *"14."* ]] || [[ $UBUNTU_VERSION == *"15."* ]] || [[ $UBUNTU_VERSION == *"16."* ]] || [[ $UBUNTU_VERSION == *"17."* ]] || [[ $UBUNTU_VERSION == *"18."* ]];
 then
     sudo apt-get -yq install python-setuptools python-dev build-essential
-    hash pip 2> /dev/null || sudo easy_install pip
-    sudo -H pip install --upgrade numpy protobuf opencv-python
+    hash pip2 2> /dev/null || sudo apt-get -yq install python-pip
+    sudo -H pip2 install pip --upgrade
+    sudo -H pip2 install --upgrade numpy protobuf opencv-python
 fi
 # Python3 libs
 sudo apt-get -yq install python3-setuptools python3-dev build-essential
-sudo apt-get -yq install python3-pip
+hash pip3 2> /dev/null || sudo apt-get -yq install python3-pip
+sudo -H pip3 install pip --upgrade
 sudo -H pip3 install --upgrade numpy protobuf opencv-python
 # OpenCL Generic (Official OpenPose support dropped after Ubuntu 20)
 if [[ $UBUNTU_VERSION == *"14."* ]] || [[ $UBUNTU_VERSION == *"15."* ]] || [[ $UBUNTU_VERSION == *"16."* ]] || [[ $UBUNTU_VERSION == *"17."* ]] || [[ $UBUNTU_VERSION == *"18."* ]]

--- a/scripts/ubuntu/install_deps.sh
+++ b/scripts/ubuntu/install_deps.sh
@@ -12,23 +12,34 @@ sudo apt-get -yq install libatlas-base-dev libprotobuf-dev libleveldb-dev libsna
 sudo apt-get -yq install --no-install-recommends libboost-all-dev
 # Remaining dependencies, 14.04
 sudo apt-get -yq install libgflags-dev libgoogle-glog-dev liblmdb-dev
-# Python2 libs (Official Ubuntu support dropped after Ubuntu 20)
-if [[ $UBUNTU_VERSION == *"14."* ]] || [[ $UBUNTU_VERSION == *"15."* ]] || [[ $UBUNTU_VERSION == *"16."* ]] || [[ $UBUNTU_VERSION == *"17."* ]] || [[ $UBUNTU_VERSION == *"18."* ]];
+if [[ ! $WITH_PYTHON == false ]]
 then
-    sudo apt-get -yq install python-setuptools python-dev build-essential
-    hash pip2 2> /dev/null || sudo apt-get -yq install python-pip
-    sudo -H pip2 install pip --upgrade
-    sudo -H pip2 install --upgrade "numpy<1.17" protobuf
-    pip2 install pip --upgrade --user
-    pip2 install --upgrade --user "opencv-python<4.3"
-else
-# Python3 libs
-    sudo apt-get -yq install python3-setuptools python3-dev build-essential
-    hash pip3 2> /dev/null || sudo apt-get -yq install python3-pip
-    sudo -H pip3 install pip --upgrade
-    sudo -H pip3 install --upgrade numpy protobuf
-    pip3 install pip --upgrade --user
-    pip3 install --upgrade --user opencv-python
+    # Python2 libs (Official Ubuntu support dropped after Ubuntu 20)
+    if [[ $UBUNTU_VERSION == *"14."* ]] || [[ $UBUNTU_VERSION == *"15."* ]] || [[ $UBUNTU_VERSION == *"16."* ]] || [[ $UBUNTU_VERSION == *"17."* ]] || [[ $UBUNTU_VERSION == *"18."* ]];
+    then
+        sudo apt-get -yq install python-setuptools python-dev build-essential
+        hash pip2 2> /dev/null || sudo apt-get -yq install python-pip
+        sudo -H pip2 install pip --upgrade
+        if [[ "$CI" == "true" ]]
+        then
+            sudo -H pip2 install --upgrade "numpy<1.17" protobuf
+            sudo -H pip2 install --user "opencv-python<4.3"
+        else
+            sudo -H pip2 install --upgrade "numpy<1.17" protobuf "opencv-python<4.3"
+        fi
+    else
+    # Python3 libs
+        sudo apt-get -yq install python3-setuptools python3-dev build-essential
+        hash pip3 2> /dev/null || sudo apt-get -yq install python3-pip
+        sudo -H pip3 install pip --upgrade
+        if [[ "$CI" == "true" ]]
+        then
+            sudo -H pip3 install --upgrade numpy protobuf
+            sudo -H pip3 install --user opencv-python
+        else
+            sudo -H pip3 install --upgrade numpy protobuf opencv-python
+        fi
+    fi
 fi
 # OpenCL Generic (Official OpenPose support dropped after Ubuntu 20)
 if [[ $UBUNTU_VERSION == *"14."* ]] || [[ $UBUNTU_VERSION == *"15."* ]] || [[ $UBUNTU_VERSION == *"16."* ]] || [[ $UBUNTU_VERSION == *"17."* ]] || [[ $UBUNTU_VERSION == *"18."* ]]

--- a/scripts/ubuntu/install_deps.sh
+++ b/scripts/ubuntu/install_deps.sh
@@ -5,27 +5,29 @@
 UBUNTU_VERSION="$(lsb_release -r)"
 
 # Basic
-sudo apt-get --assume-yes update
-sudo apt-get --assume-yes install build-essential
+sudo apt-get -yq update
+sudo apt-get -yq install build-essential
 # General dependencies
-sudo apt-get --assume-yes install libatlas-base-dev libprotobuf-dev libleveldb-dev libsnappy-dev libhdf5-serial-dev protobuf-compiler
-sudo apt-get --assume-yes install --no-install-recommends libboost-all-dev
+sudo apt-get -yq install libatlas-base-dev libprotobuf-dev libleveldb-dev libsnappy-dev libhdf5-serial-dev protobuf-compiler
+sudo apt-get -yq install --no-install-recommends libboost-all-dev
 # Remaining dependencies, 14.04
-sudo apt-get --assume-yes install libgflags-dev libgoogle-glog-dev liblmdb-dev
+sudo apt-get -yq install libgflags-dev libgoogle-glog-dev liblmdb-dev
 # Python2 libs (Official Ubuntu support dropped after Ubuntu 20)
-if [[ $UBUNTU_VERSION == *"14."* ]] || [[ $UBUNTU_VERSION == *"15."* ]] || [[ $UBUNTU_VERSION == *"16."* ]] || [[ $UBUNTU_VERSION == *"17."* ]] || [[ $UBUNTU_VERSION == *"18."* ]]; then
-	sudo apt-get --assume-yes install python-setuptools python-dev build-essential
-	sudo easy_install pip
-	sudo -H pip install --upgrade numpy protobuf opencv-python
+if [[ $UBUNTU_VERSION == *"14."* ]] || [[ $UBUNTU_VERSION == *"15."* ]] || [[ $UBUNTU_VERSION == *"16."* ]] || [[ $UBUNTU_VERSION == *"17."* ]] || [[ $UBUNTU_VERSION == *"18."* ]];
+then
+    sudo apt-get -yq install python-setuptools python-dev build-essential
+    sudo easy_install pip
+    sudo -H pip install --upgrade numpy protobuf opencv-python
 fi
 # Python3 libs
-sudo apt-get --assume-yes install python3-setuptools python3-dev build-essential
-sudo apt-get --assume-yes install python3-pip
+sudo apt-get -yq install python3-setuptools python3-dev build-essential
+sudo apt-get -yq install python3-pip
 sudo -H pip3 install --upgrade numpy protobuf opencv-python
 # OpenCL Generic (Official OpenPose support dropped after Ubuntu 20)
-if [[ $UBUNTU_VERSION == *"14."* ]] || [[ $UBUNTU_VERSION == *"15."* ]] || [[ $UBUNTU_VERSION == *"16."* ]] || [[ $UBUNTU_VERSION == *"17."* ]] || [[ $UBUNTU_VERSION == *"18."* ]]; then
-	sudo apt-get --assume-yes install opencl-headers ocl-icd-opencl-dev
-	sudo apt-get --assume-yes install libviennacl-dev
+if [[ $UBUNTU_VERSION == *"14."* ]] || [[ $UBUNTU_VERSION == *"15."* ]] || [[ $UBUNTU_VERSION == *"16."* ]] || [[ $UBUNTU_VERSION == *"17."* ]] || [[ $UBUNTU_VERSION == *"18."* ]]
+then
+    sudo apt-get -yq install opencl-headers ocl-icd-opencl-dev
+    sudo apt-get -yq install libviennacl-dev
 fi
 # OpenCV 2.4 -> Added as option
 # # sudo apt-get --assume-yes install libopencv-dev

--- a/scripts/ubuntu/install_deps.sh
+++ b/scripts/ubuntu/install_deps.sh
@@ -16,7 +16,7 @@ sudo apt-get -yq install libgflags-dev libgoogle-glog-dev liblmdb-dev
 if [[ $UBUNTU_VERSION == *"14."* ]] || [[ $UBUNTU_VERSION == *"15."* ]] || [[ $UBUNTU_VERSION == *"16."* ]] || [[ $UBUNTU_VERSION == *"17."* ]] || [[ $UBUNTU_VERSION == *"18."* ]];
 then
     sudo apt-get -yq install python-setuptools python-dev build-essential
-    sudo easy_install pip
+    hash pip 2> /dev/null || sudo easy_install pip
     sudo -H pip install --upgrade numpy protobuf opencv-python
 fi
 # Python3 libs

--- a/scripts/ubuntu/install_deps.sh
+++ b/scripts/ubuntu/install_deps.sh
@@ -19,25 +19,25 @@ then
     then
         sudo apt-get -yq install python-setuptools python-dev build-essential
         hash pip2 2> /dev/null || sudo apt-get -yq install python-pip
-        sudo -H pip2 install pip --upgrade
+        sudo -H python2 -m pip install pip --upgrade
         if [[ "$CI" == "true" ]]
         then
-            sudo -H pip2 install --upgrade "numpy<1.17" protobuf
-            sudo -H pip2 install --user "opencv-python<4.3"
+            sudo -H python2 -m pip install --upgrade "numpy<1.17" protobuf
+            python2 -m pip install --user "opencv-python<4.3"
         else
-            sudo -H pip2 install --upgrade "numpy<1.17" protobuf "opencv-python<4.3"
+            sudo -H python2 -m pip install --upgrade "numpy<1.17" protobuf "opencv-python<4.3"
         fi
     else
     # Python3 libs
         sudo apt-get -yq install python3-setuptools python3-dev build-essential
         hash pip3 2> /dev/null || sudo apt-get -yq install python3-pip
-        sudo -H pip3 install pip --upgrade
+        sudo -H python3 -m pip install pip --upgrade
         if [[ "$CI" == "true" ]]
         then
-            sudo -H pip3 install --upgrade numpy protobuf
-            sudo -H pip3 install --user opencv-python
+            sudo -H python3 -m pip install --upgrade numpy protobuf
+            python3 -m pip install --user opencv-python
         else
-            sudo -H pip3 install --upgrade numpy protobuf opencv-python
+            sudo -H python3 -m pip install --upgrade numpy protobuf opencv-python
         fi
     fi
 fi

--- a/scripts/ubuntu/install_deps.sh
+++ b/scripts/ubuntu/install_deps.sh
@@ -19,6 +19,7 @@ then
     hash pip2 2> /dev/null || sudo apt-get -yq install python-pip
     sudo -H pip2 install pip --upgrade
     sudo -H pip2 install --upgrade numpy protobuf
+    pip2 install pip --upgrade --user
     pip2 install --upgrade --user "opencv-python<4.3"
 else
 # Python3 libs
@@ -26,6 +27,7 @@ else
     hash pip3 2> /dev/null || sudo apt-get -yq install python3-pip
     sudo -H pip3 install pip --upgrade
     sudo -H pip3 install --upgrade numpy protobuf
+    pip3 install pip --upgrade --user
     pip3 install --upgrade --user opencv-python
 fi
 # OpenCL Generic (Official OpenPose support dropped after Ubuntu 20)

--- a/scripts/ubuntu/install_deps.sh
+++ b/scripts/ubuntu/install_deps.sh
@@ -18,7 +18,7 @@ then
     sudo apt-get -yq install python-setuptools python-dev build-essential
     hash pip2 2> /dev/null || sudo apt-get -yq install python-pip
     sudo -H pip2 install pip --upgrade
-    sudo -H pip2 install --upgrade numpy protobuf
+    sudo -H pip2 install --upgrade "numpy<1.17" protobuf
     pip2 install pip --upgrade --user
     pip2 install --upgrade --user "opencv-python<4.3"
 else

--- a/scripts/ubuntu/install_deps.sh
+++ b/scripts/ubuntu/install_deps.sh
@@ -18,13 +18,15 @@ then
     sudo apt-get -yq install python-setuptools python-dev build-essential
     hash pip2 2> /dev/null || sudo apt-get -yq install python-pip
     sudo -H pip2 install pip --upgrade
-    sudo -H pip2 install --upgrade numpy protobuf "opencv-python<4.3"
+    sudo -H pip2 install --upgrade numpy protobuf
+    pip2 install --upgrade --user "opencv-python<4.3"
 else
 # Python3 libs
     sudo apt-get -yq install python3-setuptools python3-dev build-essential
     hash pip3 2> /dev/null || sudo apt-get -yq install python3-pip
     sudo -H pip3 install pip --upgrade
-    sudo -H pip3 install --upgrade numpy protobuf opencv-python
+    sudo -H pip3 install --upgrade numpy protobuf
+    pip3 install --upgrade --user opencv-python
 fi
 # OpenCL Generic (Official OpenPose support dropped after Ubuntu 20)
 if [[ $UBUNTU_VERSION == *"14."* ]] || [[ $UBUNTU_VERSION == *"15."* ]] || [[ $UBUNTU_VERSION == *"16."* ]] || [[ $UBUNTU_VERSION == *"17."* ]] || [[ $UBUNTU_VERSION == *"18."* ]]

--- a/scripts/ubuntu/install_deps.sh
+++ b/scripts/ubuntu/install_deps.sh
@@ -18,7 +18,7 @@ then
     sudo apt-get -yq install python-setuptools python-dev build-essential
     hash pip2 2> /dev/null || sudo apt-get -yq install python-pip
     sudo -H pip2 install pip --upgrade
-    sudo -H pip2 install --upgrade numpy protobuf opencv-python
+    sudo -H pip2 install --upgrade numpy protobuf "opencv-python<4.3"
 fi
 # Python3 libs
 sudo apt-get -yq install python3-setuptools python3-dev build-essential

--- a/scripts/ubuntu/install_deps.sh
+++ b/scripts/ubuntu/install_deps.sh
@@ -19,12 +19,13 @@ then
     hash pip2 2> /dev/null || sudo apt-get -yq install python-pip
     sudo -H pip2 install pip --upgrade
     sudo -H pip2 install --upgrade numpy protobuf "opencv-python<4.3"
-fi
+else
 # Python3 libs
-sudo apt-get -yq install python3-setuptools python3-dev build-essential
-hash pip3 2> /dev/null || sudo apt-get -yq install python3-pip
-sudo -H pip3 install pip --upgrade
-sudo -H pip3 install --upgrade numpy protobuf opencv-python
+    sudo apt-get -yq install python3-setuptools python3-dev build-essential
+    hash pip3 2> /dev/null || sudo apt-get -yq install python3-pip
+    sudo -H pip3 install pip --upgrade
+    sudo -H pip3 install --upgrade numpy protobuf opencv-python
+fi
 # OpenCL Generic (Official OpenPose support dropped after Ubuntu 20)
 if [[ $UBUNTU_VERSION == *"14."* ]] || [[ $UBUNTU_VERSION == *"15."* ]] || [[ $UBUNTU_VERSION == *"16."* ]] || [[ $UBUNTU_VERSION == *"17."* ]] || [[ $UBUNTU_VERSION == *"18."* ]]
 then

--- a/scripts/ubuntu/install_deps_and_cuda.sh
+++ b/scripts/ubuntu/install_deps_and_cuda.sh
@@ -3,10 +3,10 @@
 ### INSTALL PREREQUISITES
 
 # Install CUDA 8.0
-bash scripts/ubuntu/install_cuda.sh
+source scripts/ubuntu/install_cuda.sh
 
 # Install cuDNN 5.1
-bash scripts/ubuntu/install_cudnn.sh
+source scripts/ubuntu/install_cudnn.sh
 
 # Caffe prerequisites
-bash scripts/ubuntu/install_deps.sh
+source scripts/ubuntu/install_deps.sh


### PR DESCRIPTION
Result on my actions: https://github.com/MatthijsBurgh/openpose/actions/runs/449344457

The CUDA jobs fails because of an issue with GCC 5.5, https://github.com/NVIDIA/apex/issues/529. GH Actions doesn't support GCC 5.4. And CUDA doesn't support newer than GCC 5.X. So I don't have a solution for these jobs.

This might not be the cleanest PR. I suggest to cleanup the scripts further so that are generic scripts, CI scripts, Travis scripts and GH action scripts, etc. And that all TRAVIS/GH Action variables are only use in their specific scripts and generic variables in the other scripts.

Because of the failing jobs, I haven't been able to test the docs generation. I don't know if the DOCS could be generated after another job.

P.S. Setup a branch protection and require these jobs to succeed. I have seen the TRAVIS job history getting worse over time. This shouldn't happen.

Solves #1809 