### PR TITLE
(OSX) replace outdated ruby installer of brew

### DIFF
--- a/scripts/osx/install_brew.sh
+++ b/scripts/osx/install_brew.sh
@@ -1,3 +1,3 @@
 xcode-select --install
-ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 brew update


### PR DESCRIPTION
As suggested in https://github.com/CMU-Perceptual-Computing-Lab/openpose/runs/1699056384?check_suite_focus=true#step:6:20