### PR TITLE
Add root index.html so no need for crazy url for docs

### DIFF
--- a/.github/root_index.html
+++ b/.github/root_index.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv = "refresh" content = "0; url = web/html/doc/index.html" />
+    </head>
+    <body>
+    </body>
+</html>

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -269,9 +269,6 @@ jobs:
         cd ${{ github.workspace }}
         echo 'Generating Doxygen code documentation...'
         doxygen $DOXYFILE 2>&1 | tee doxygen.log
-        echo 'Creating .nojekyll and copying log...'
-        echo "" > doxygen/html/.nojekyll
-        cp doxygen.log doxygen/html/doxygen.log
         # Required so Doxygen links/finds the license file
         cp LICENSE doxygen/html/LICENSE
         # Required in order to link .github/media/ images with doc without modifying doc links. Remove if using `publish_dir: doxygen/html/`
@@ -279,6 +276,8 @@ jobs:
         mkdir -p doxygen_final/web/.github/media/ && cp -rf .github/media/ doxygen_final/web/.github/
         mkdir -p doxygen_final/web/html/.github/media/ && cp -rf .github/media/ doxygen_final/web/html/.github/
         mkdir -p doxygen_final/web/html/doc/.github/media/ && cp -rf .github/media/ doxygen_final/web/html/doc/.github/
+        echo 'Copying log...'
+        cp doxygen.log doxygen_final/doxygen.log
         echo 'Copying index.html to root pointing to actual docs'
         cp .github/root_index.html doxygen_final/index.html
       if: ${{ matrix.DOCS }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -279,6 +279,8 @@ jobs:
         mkdir -p doxygen_final/web/.github/media/ && cp -rf .github/media/ doxygen_final/web/.github/
         mkdir -p doxygen_final/web/html/.github/media/ && cp -rf .github/media/ doxygen_final/web/html/.github/
         mkdir -p doxygen_final/web/html/doc/.github/media/ && cp -rf .github/media/ doxygen_final/web/html/doc/.github/
+        echo 'Copying index.html to root pointing to actual docs'
+        cp .github/root_index.html doxygen_final/index.html
       if: ${{ matrix.DOCS }}
     - name: Deploy Docs
       uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
Now the url can be reduced to [cmu-perceptual-computing-lab.github.io/openpose/](https://cmu-perceptual-computing-lab.github.io/openpose/)

I have tested it by manually adding the file to my `gh-pages` branch. See [matthijsburgh.github.io/openpose](https://matthijsburgh.github.io/openpose) So the file is correct, hopefully I made no mistakes in the procedure to copy the file.