### PR TITLE
Use `Type` as cast, not constructor.

### DIFF
--- a/src/openpose/net/bodyPartConnectorBaseCL.cpp
+++ b/src/openpose/net/bodyPartConnectorBaseCL.cpp
@@ -69,7 +69,7 @@ namespace op
                         const Type l2Dist = sqrt((Type)(vectorAToBX*vectorAToBX + vectorAToBY*vectorAToBY));
                         const Type threshold = sqrt((Type)(heatmapWidth*heatmapHeight))/150; // 3.3 for 368x656, 6.6 for 2x resolution
                         if (l2Dist < threshold)
-                            return Type(defaultNmsThreshold+1e-6); // Without 1e-6 will not work because I use strict greater
+                            return (Type)(defaultNmsThreshold+1e-6); // Without 1e-6 will not work because I use strict greater
                     }
                 }
                 return -1;


### PR DESCRIPTION
Fixes CMU-Perceptual-Computing-Lab/openpose#1879

Without the extra parens around `Type`, it is considered a function call. Because `Type` gets substitute with `float`, which is not a function and OpenCL does not have constructors for native types, this results in "error: expected expression."