### PR TITLE
Update Mac cmake-gui install instructions

### DIFF
--- a/doc/installation/1_prerequisites.md
+++ b/doc/installation/1_prerequisites.md
@@ -73,7 +73,7 @@ sudo pip install numpy opencv-python
 
 ## Mac OS Prerequisites
 1. If you don't have `brew`, install it by running `bash scripts/osx/install_brew.sh` on your terminal.
-2. Install **CMake GUI**: Run the command `brew cask install cmake`.
+2. Install **CMake GUI**: Download the binaries from [CMake Downloads](https://cmake.org/download/). The command line version of cmake may be installed with the command `brew install --cask cmake`, but this no longer includes the GUI program.
 3. Install **Caffe, OpenCV, and Caffe prerequisites**: Run `bash scripts/osx/install_deps.sh`.
 
 


### PR DESCRIPTION
The command to use brew cask no longer works. The new version is `brew install --cask cmake`. This installs the CLI version, but no longer includes the GUI. The GUI version is included in the binaries available from the cmake web page. Note that this current update is distinct from PR #1765.