### PR TITLE
Fix bugs in setAngleInRangeZeroTwoPi

### DIFF
--- a/src/openpose/calibration/cameraParameterEstimation.cpp
+++ b/src/openpose/calibration/cameraParameterEstimation.cpp
@@ -196,7 +196,7 @@ namespace op
         try
         {
             // Return angle in range [0,2pi)
-            return std::fmod(angle, 360);    // floating-point remainder
+            return std::fmod(angle + 2 * PI, 2 * PI);    // floating-point remainder
             // double result{angle};
 
             // Return angle in range [0,2pi)


### PR DESCRIPTION
The function would compute the angle modulo 360, not 2pi as the function's name promises. Additionally, [fmod](https://en.cppreference.com/w/cpp/numeric/math/fmod) returns negative values if the argument is negative, which we also don't want. This can be fixed by adding 2pi to the argument - assuming the angle is not lower than -2pi.

This function is used in camera calibration, which is how I found the bug. OpenPose would mistakenly report that there are outliers in the angles, but this was due to `setAngleInRangeZeroTwoPi` not working properly.