### PR TITLE
Update cmake installation on mac

### DIFF
--- a/doc/installation/1_prerequisites.md
+++ b/doc/installation/1_prerequisites.md
@@ -76,7 +76,7 @@ sudo pip install numpy opencv-python
 
 ## Mac OS Prerequisites
 1. If you don't have `brew`, install it by running `bash scripts/osx/install_brew.sh` on your terminal.
-2. Install **CMake GUI**: Run the command `brew cask install cmake`.
+2. Install **CMake GUI**: Run the command `brew install cmake --cask`.
 3. Install **Caffe, OpenCV, and Caffe prerequisites**: Run `bash scripts/osx/install_deps.sh`.
 
 


### PR DESCRIPTION
Brew now uses "brew install <package> --cask" format for installations. Upgraded accordingly.