### PR TITLE
Update openpose_python.cpp

### DIFF
--- a/python/openpose/openpose_python.cpp
+++ b/python/openpose/openpose_python.cpp
@@ -469,7 +469,7 @@ template <> struct type_caster<op::Array<float>> {
         {
             UNUSED(defval);
             if (m.getSize().size() == 0) {
-                return none();
+                return Py_BuildValue("");
             }
             std::string format = format_descriptor<float>::format();
             return array(buffer_info(
@@ -505,7 +505,7 @@ template <> struct type_caster<op::Array<long long>> {
         {
             UNUSED(defval);
             if (m.getSize().size() == 0) {
-                return none();
+                return Py_BuildValue("");
             }
             std::string format = format_descriptor<long long>::format();
             return array(buffer_info(


### PR DESCRIPTION
There is a missing allocation of `Py_None` objects in `openpose_python.cpp`.

Here is a discussion why it is necessary to increment the reference count on None when writing C++: 

https://stackoverflow.com/questions/69588623/my-python-program-crashes-with-fatal-python-error-deallocating-none-what-doe

Here are possible solutions:
https://stackoverflow.com/questions/15287590/why-should-py-increfpy-none-be-required-before-returning-py-none-in-c/15288194#15288194

I choose `Py_BuildValue("")` because it uses the native python C API.

In my test-setup, I use RTSP with 15 cameras to continuously read images from the streams, apply openpose and store the results in a database. Before my change to the codebase, the counter of `NoneType` in python slowly decremented and hit below 0 after 15 min. With the change, the `NoneType` count is stable and the cameras can run continuously.