### PR TITLE
Test fix for OSX CI

### DIFF
--- a/scripts/osx/install_deps.sh
+++ b/scripts/osx/install_deps.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-brew_packages="openblas snappy leveldb gflags glog szip lmdb hdf5 opencv protobuf boost cmake viennacl"
+brew_packages="openblas snappy leveldb gflags glog libaec lmdb hdf5 opencv protobuf boost cmake viennacl"
 for pkg in $brew_packages
 do
     echo "brew install $pkg || brew upgrade $pkg"


### PR DESCRIPTION
According to https://github.com/MathisRosenhauer/libaec/blob/master/README.SZIP
The replacement should be just "drop in"
Might work, might not. Let's try.