### PR TITLE
(OSX) do not install szip

### DIFF
--- a/scripts/osx/install_deps.sh
+++ b/scripts/osx/install_deps.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-brew_packages="openblas snappy leveldb gflags glog szip lmdb hdf5 opencv protobuf boost cmake viennacl"
+brew_packages="openblas snappy leveldb gflags glog lmdb hdf5 opencv protobuf boost cmake viennacl"
 for pkg in $brew_packages
 do
     echo "brew install $pkg || brew upgrade $pkg"


### PR DESCRIPTION
szip is removed, see https://github.com/Homebrew/homebrew-core/issues/96930

Requires https://github.com/CMU-Perceptual-Computing-Lab/caffe/pull/5 to be merged and then implemented in this PR.