### PR TITLE
Fix wrong string declared in poseParameters.cpp

### DIFF
--- a/src/openpose/pose/poseParameters.cpp
+++ b/src/openpose/pose/poseParameters.cpp
@@ -137,7 +137,7 @@ namespace op
         {14, "RKnee"},
         {15, "LAnkle"},
         {16, "RAnkle"},
-        {17, "UpperNeck"},
+        {17, "Neck"},
         {18, "HeadTop"},
         {19, "LBigToe"},
         {20, "LSmallToe"},


### PR DESCRIPTION
I've tried using the POSE_25B and encountered a "String(s) could not be found" error. This PR fixes it.