### PR TITLE
Update cmake min version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,13 +25,13 @@ if (${CMAKE_VERSION} VERSION_GREATER 3.9.0)
   # # else
   # set(AUTO_FOUND_CUDA FALSE)
 # Ubuntu 16 default
-elseif (${CMAKE_VERSION} VERSION_GREATER 3.0.0)
+elseif (${CMAKE_VERSION} VERSION_GREATER 3.5.0)
   cmake_policy(SET CMP0048 NEW)
   project(OpenPose VERSION ${OpenPose_VERSION})
 else (${CMAKE_VERSION} VERSION_GREATER 3.9.0)
   project(OpenPose)
 endif (${CMAKE_VERSION} VERSION_GREATER 3.9.0)
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR) # required by cmake eigen finder to find locally installed versions (e.g., CUDA 9.2 support was added in eigen 3.3.5)
+cmake_minimum_required(VERSION 3.5.0 FATAL_ERROR) # required by cmake eigen finder to find locally installed versions (e.g., CUDA 9.2 support was added in eigen 3.3.5)
 # cmake_minimum_required(VERSION 2.8.7 FATAL_ERROR) # min. cmake version recommended by Caffe
 
 


### PR DESCRIPTION
Fixes [Issue 2339](https://github.com/CMU-Perceptual-Computing-Lab/openpose/issues/2339)

CMake 4.0 removed support for policy versions earlier than 3.5. This change updates the minimum required version to 3.5 to ensure compatibility with CMake 4.x and prevent configuration errors.